### PR TITLE
travis: allow rustfmt to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ matrix:
         - cargo fmt -- --check
   allow_failures:
     - rust: nightly
+    - env: RUSTFMT
 script: cargo test --release --verbose --all

--- a/spake2/src/lib.rs
+++ b/spake2/src/lib.rs
@@ -2,8 +2,8 @@
 #![deny(warnings)]
 #![forbid(unsafe_code)]
 
-extern crate curve25519_dalek;
 extern crate hex;
+extern crate curve25519_dalek;
 extern crate hkdf;
 extern crate num_bigint;
 extern crate rand;


### PR DESCRIPTION
I'm on the fence about this, but I have to admit that having your PR fail
because of formatting issues isn't a great experience for new contributors.

We will need to run `cargo fmt` ourselves on a regular basis.

NOTE: don't merge this, I'm still testing the .travis.yml syntax.