### PR TITLE
More idiomatic Debug impl

### DIFF
--- a/spake2/src/lib.rs
+++ b/spake2/src/lib.rs
@@ -358,6 +358,7 @@ pub trait Group {
     // const element_length: usize; // in unstable, or u8
     //type ElementBytes : Index<usize, Output=u8>+IndexMut<usize>; // later
     type TranscriptHash;
+    fn name() -> &'static str;
     fn const_m() -> Self::Element;
     fn const_n() -> Self::Element;
     fn const_s() -> Self::Element;
@@ -384,6 +385,10 @@ impl Group for Ed25519Group {
     //type ElementBytes = [u8; 32];
     //type ScalarBytes
     type TranscriptHash = Sha256;
+
+    fn name() -> &'static str {
+        "Ed25519"
+    }
 
     fn const_m() -> c2_Element {
         // python -c "import binascii, spake2; b=binascii.hexlify(spake2.ParamsEd25519.M.to_bytes()); print(', '.join(['0x'+b[i:i+2] for i in range(0,len(b),2)]))"
@@ -822,6 +827,7 @@ fn maybe_utf8(s: &[u8]) -> String {
 impl<G: Group> fmt::Debug for SPAKE2<G> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("SPAKE2")
+            .field("group", &G::name())
             .field("side", &self.side)
             .field("idA", &maybe_utf8(&self.id_a))
             .field("idB", &maybe_utf8(&self.id_b))

--- a/spake2/src/lib.rs
+++ b/spake2/src/lib.rs
@@ -820,15 +820,13 @@ fn maybe_utf8(s: &[u8]) -> String {
 }
 
 impl<G: Group> fmt::Debug for SPAKE2<G> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "SPAKE2(G=?, side={:?}, idA={}, idB={}, idS={})",
-            self.side,
-            maybe_utf8(&self.id_a),
-            maybe_utf8(&self.id_b),
-            maybe_utf8(&self.id_s)
-        )
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("SPAKE2")
+            .field("side", &self.side)
+            .field("idA", &maybe_utf8(&self.id_a))
+            .field("idB", &maybe_utf8(&self.id_b))
+            .field("idS", &maybe_utf8(&self.id_s))
+            .finish()
     }
 }
 

--- a/spake2/src/tests.rs
+++ b/spake2/src/tests.rs
@@ -185,9 +185,16 @@ fn test_debug() {
         &Identity::new(b"idB"),
     );
     println!("s1: {:?}", s1);
+    assert_eq!(
+        format!("{:?}", s1),
+        "SPAKE2 { group: \"Ed25519\", side: A, idA: \"(s=idA)\", idB: \"(s=idB)\", idS: \"(s=)\" }"
+    );
+
     let (s2, _msg1) = SPAKE2::<Ed25519Group>::start_symmetric(
         &Password::new(b"password"),
         &Identity::new(b"idS"),
     );
     println!("s2: {:?}", s2);
+    assert_eq!(format!("{:?}", s2),
+               "SPAKE2 { group: \"Ed25519\", side: Symmetric, idA: \"(s=)\", idB: \"(s=)\", idS: \"(s=idS)\" }");
 }


### PR DESCRIPTION
`debug_struct` is built in and makes your Debug impl more consistent with others.

I noodled for a while over trying to make it also tell you which Group it's  generic over, I don't think there's a way to do it unmodified, but you can either add a Default bound to it, or just add a `name()` fn to the Group trait.