### PR TITLE
update everything to the "2018 edition" of Rust

### DIFF
--- a/spake2/Cargo.toml
+++ b/spake2/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "spake2"
 version = "0.1.2-alpha.0"
+edition = "2018"
 authors = ["Brian Warner <warner@lothar.com>"]
 description = "The SPAKE2 password-authenticated key-exchange algorithm."
 documentation = "https://docs.rs/spake2"

--- a/spake2/benches/spake2.rs
+++ b/spake2/benches/spake2.rs
@@ -1,9 +1,5 @@
-#[macro_use]
-extern crate bencher;
-
-extern crate spake2;
-
 use bencher::Bencher;
+use bencher::{benchmark_group, benchmark_main};
 use spake2::{Ed25519Group, Identity, Password, SPAKE2};
 
 fn spake2_start(bench: &mut Bencher) {

--- a/spake2/src/lib.rs
+++ b/spake2/src/lib.rs
@@ -288,18 +288,10 @@
 #![deny(warnings)]
 #![forbid(unsafe_code)]
 
-extern crate curve25519_dalek;
-extern crate hex;
-extern crate hkdf;
-extern crate num_bigint;
-extern crate rand;
-extern crate sha2;
-
 use curve25519_dalek::constants::ED25519_BASEPOINT_POINT;
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::edwards::EdwardsPoint as c2_Element;
 use curve25519_dalek::scalar::Scalar as c2_Scalar;
-
 use hkdf::Hkdf;
 use rand::{rngs::OsRng, CryptoRng, Rng};
 use sha2::{Digest, Sha256};
@@ -828,7 +820,7 @@ fn maybe_utf8(s: &[u8]) -> String {
 }
 
 impl<G: Group> fmt::Debug for SPAKE2<G> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("SPAKE2")
             .field("group", &G::name())
             .field("side", &self.side)

--- a/spake2/tests/mod.rs
+++ b/spake2/tests/mod.rs
@@ -1,5 +1,3 @@
-extern crate spake2;
-
 use spake2::{Ed25519Group, ErrorType, Identity, Password, SPAKEErr, SPAKE2};
 
 #[test]

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "srp"
 version = "0.3.0"
+edition = "2018"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Secure Remote Password (SRP) protocol implementation"

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srp"
-version = "0.3.0"
+version = "0.4.0-alpha.0"
 edition = "2018"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/srp/src/client.rs
+++ b/srp/src/client.rs
@@ -133,7 +133,7 @@ impl<'a, D: Digest> SrpClient<'a, D> {
         let k = self.params.compute_k::<D>();
         let interm = (k * self.params.powm(x)) % n;
         // Because we do operation in modulo N we can get: (kv + g^b) < kv
-        let v = if b_pub > &interm {
+        let v = if *b_pub > interm {
             (b_pub - &interm) % n
         } else {
             (n + b_pub - &interm) % n
@@ -186,9 +186,9 @@ impl<'a, D: Digest> SrpClient<'a, D> {
         };
 
         Ok(SrpClientVerifier {
-            proof: proof,
-            server_proof: server_proof,
-            key: key,
+            proof,
+            server_proof,
+            key,
         })
     }
 

--- a/srp/src/client.rs
+++ b/srp/src/client.rs
@@ -62,8 +62,8 @@ use digest::Digest;
 use generic_array::GenericArray;
 use num::{BigUint, Zero};
 
-use tools::powm;
-use types::{SrpAuthError, SrpGroup};
+use crate::tools::powm;
+use crate::types::{SrpAuthError, SrpGroup};
 
 /// SRP client state before handshake with the server.
 pub struct SrpClient<'a, D: Digest> {

--- a/srp/src/groups.rs
+++ b/srp/src/groups.rs
@@ -4,6 +4,7 @@
 //! groups. Additionally it is not recommended to use `G_1024` and `G_1536`,
 //! they are provided only for compatibility with the legacy software.
 use crate::types::SrpGroup;
+use lazy_static::lazy_static;
 use num::BigUint;
 
 lazy_static! {

--- a/srp/src/groups.rs
+++ b/srp/src/groups.rs
@@ -3,8 +3,8 @@
 //! It is strongly recommended to use them instead of custom generated
 //! groups. Additionally it is not recommended to use `G_1024` and `G_1536`,
 //! they are provided only for compatibility with the legacy software.
+use crate::types::SrpGroup;
 use num::BigUint;
-use types::SrpGroup;
 
 lazy_static! {
     pub static ref G_1024: SrpGroup = SrpGroup {

--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -64,14 +64,6 @@
 //! [1]: https://en.wikipedia.org/wiki/Secure_Remote_Password_protocol
 //! [2]: https://tools.ietf.org/html/rfc5054
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-extern crate digest;
-extern crate generic_array;
-extern crate num;
-#[macro_use]
-extern crate lazy_static;
-
-#[cfg(test)]
-extern crate sha1;
 
 pub mod client;
 pub mod groups;

--- a/srp/src/server.rs
+++ b/srp/src/server.rs
@@ -65,7 +65,7 @@ pub struct SrpServer<D: Digest> {
 impl<D: Digest> SrpServer<D> {
     /// Create new server state.
     pub fn new(
-        user: &UserRecord,
+        user: &UserRecord<'_>,
         a_pub: &[u8],
         b: &[u8],
         params: &SrpGroup,

--- a/srp/src/server.rs
+++ b/srp/src/server.rs
@@ -40,8 +40,8 @@ use digest::Digest;
 use generic_array::GenericArray;
 use num::{BigUint, Zero};
 
-use tools::powm;
-use types::{SrpAuthError, SrpGroup};
+use crate::tools::powm;
+use crate::types::{SrpAuthError, SrpGroup};
 
 /// Data provided by users upon registration, usually stored in the database.
 pub struct UserRecord<'a> {

--- a/srp/src/tools.rs
+++ b/srp/src/tools.rs
@@ -12,7 +12,7 @@ pub fn powm(base: &BigUint, exp: &BigUint, modulus: &BigUint) -> BigUint {
         if &exp % &two == one {
             result = (result * &base) % modulus;
         }
-        exp = exp >> 1;
+        exp >>= 1;
         base = (&base * &base) % modulus;
     }
     result

--- a/srp/src/types.rs
+++ b/srp/src/types.rs
@@ -1,8 +1,8 @@
 //! Additional SRP types.
+use crate::tools::powm;
 use digest::Digest;
 use num::BigUint;
 use std::{error, fmt};
-use tools::powm;
 
 /// SRP authentification error.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -53,7 +53,7 @@ impl SrpGroup {
 
 #[cfg(test)]
 mod tests {
-    use groups::G_1024;
+    use crate::groups::G_1024;
     use sha1::Sha1;
 
     #[test]

--- a/srp/src/types.rs
+++ b/srp/src/types.rs
@@ -11,7 +11,7 @@ pub struct SrpAuthError {
 }
 
 impl fmt::Display for SrpAuthError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SRP authentification error")
     }
 }

--- a/srp/tests/mod.rs
+++ b/srp/tests/mod.rs
@@ -1,8 +1,4 @@
-extern crate num;
-extern crate rand;
-extern crate sha2;
-extern crate srp;
-
+use rand;
 use rand::RngCore;
 use sha2::Sha256;
 


### PR DESCRIPTION
@newpavlov see if you agree with these changes. The imports are simpler, and/but it requires the latest stable Rust-1.31 (released today) to compile.
