### PR TITLE
travis: exercise 1.31.1 and 1.32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.31.1
+  - 1.32
 matrix:
   include:
     - rust: 1.31.0 # lock down for consistent rustfmt behavior
@@ -14,4 +16,5 @@ matrix:
   allow_failures:
     - rust: nightly
     - env: RUSTFMT
+    - rust: 1.31.1
 script: cargo test --release --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - beta
   - nightly
   - 1.31.1
-  - 1.32
+  - 1.32.0
 matrix:
   include:
     - rust: 1.31.0 # lock down for consistent rustfmt behavior

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.31.1
   - 1.32.0
 matrix:
   include:
@@ -16,5 +15,4 @@ matrix:
   allow_failures:
     - rust: nightly
     - env: RUSTFMT
-    - rust: 1.31.1
 script: cargo test --release --verbose --all

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ the memory.
 | [SRP][2]  | [![crates.io](https://img.shields.io/crates/v/srp.svg)](https://crates.io/crates/srp) | [![Documentation](https://docs.rs/srp/badge.svg)](https://docs.rs/srp) |
 | [spake2][4]  | [![crates.io](https://img.shields.io/crates/v/spake2.svg)](https://crates.io/crates/spake2) | [![Documentation](https://docs.rs/spake2/badge.svg)](https://docs.rs/spake2) |
 
+## Rust version requirements
+
+The MSRV (Minimum Supported Rust Version) is 1.32.0 . If/when this changes,
+it will be noted in the changelog, and the crate semver will be updated. So
+downstream projects should depend upon e.g. `spake2 = "0.2"` to avoid picking
+up new versions that would require a newer compiler.
+
+SRP-v0.4.1 actually works with rustc-1.31.1, but this will probably be
+changed in the next release.
+
+SPAKE2 required rustc-1.32 beginning with spake2-v0.2.0 .
+
+Our CI scripts check all builds against a pinned version of rustc to test the
+intended MSRV. Sometimes upstream dependencies make surprising changes that
+could require a newer version of rustc, without changes to the source code in
+this repository, but hopefully this won't happen very frequently.
+
 ## License
 
 All crates are licensed under either of


### PR DESCRIPTION
1.31.1 is our intended MSRV (Minimum Supported Rust Version), but we probably
don't actually work there because of an insufficiently-constrained dependency
that requires 1.32.

1.32 is probably our actual MSRV, and will be the one we aim for going
forward.

refs #21