### PR TITLE
travis: use rust 'stable' for rustfmt check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
   - 1.32.0
 matrix:
   include:
-    - rust: 1.31.0 # lock down for consistent rustfmt behavior
+    - rust: stable # not locked down or consistent, since allow_failures
       env: RUSTFMT
       install:
         - rustup component add rustfmt-preview


### PR DESCRIPTION
This was previously locked down at a specific version (1.31.0, much older
than the current 1.36), so we'd get consistent behavior over time. But since
we allow the rustfmt build to fail (it's in allow_failures), we don't need
this consistency so much. PR authors are expected to format their code
against the current stable rustfmt, but test it against the MSRV (currently
1.32.0).

refs #21