### PR TITLE
spake2: tighten the curve25519-dalek dependency to 1.2.x

### DIFF
--- a/spake2/Cargo.toml
+++ b/spake2/Cargo.toml
@@ -26,7 +26,7 @@ is-it-maintained-issue-resolution = { repository = "RustCrypto/PAKEs" }
 is-it-maintained-open-issues = { repository = "RustCrypto/PAKEs" }
 
 [dependencies]
-curve25519-dalek = "1"
+curve25519-dalek = "1.2"
 rand = "0.6"
 sha2 = "0.8"
 hkdf = "0.8"


### PR DESCRIPTION
This was just "1", which allowed our MSRV to be accidentally raised from 1.31
to 1.32 without a deliberate spake2 minor-version bump (dalek-1.0.x compiles
with rustc-1.31, but dalek-1.1.x required 1.32).

Hopefully by making it "1.2", our MSRV will remain at 1.32 until we
explicitly decide to take on a dependency that needs something newer.

refs #21