### PR TITLE
Implement proof generation as per RFC2945.

### DIFF
--- a/srp/src/server.rs
+++ b/srp/src/server.rs
@@ -159,7 +159,7 @@ impl<'a, D: Digest> SrpServer<'a, D> {
             d.input(self.user.salt);
             d.input(&self.a_pub.to_bytes_be());
             d.input(&self.b_pub.to_bytes_be());
-            d.input(&self.key);;
+            d.input(&self.key);
             d.result()
         };
 

--- a/srp/tests/mod.rs
+++ b/srp/tests/mod.rs
@@ -37,7 +37,9 @@ fn auth_test(reg_pwd: &[u8], auth_pwd: &[u8]) {
 
     // Client processes handshake reply
     let auth_priv_key = srp_private_key::<Sha256>(username, auth_pwd, salt);
-    let client2 = client.process_reply(&auth_priv_key, &b_pub).unwrap();
+    let client2 = client
+        .process_reply(user.username, user.salt, &auth_priv_key, &b_pub)
+        .unwrap();
     let proof = client2.get_proof();
 
     // Server processes verification data


### PR DESCRIPTION
This is a backward-incompatible change.

For details, refer to:

 - https://tools.ietf.org/html/rfc2945
 - https://tools.ietf.org/html/rfc5054
 - http://srp.stanford.edu/design.html
 - https://github.com/RustCrypto/PAKEs/issues/20

This resolves issue #20.