### PR TITLE
update rand and curve25519-dalek crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.32.0
+  - 1.36.0
 matrix:
   include:
     - rust: stable # not locked down or consistent, since allow_failures

--- a/README.md
+++ b/README.md
@@ -22,15 +22,18 @@ the memory.
 
 ## Rust version requirements
 
-The MSRV (Minimum Supported Rust Version) is 1.32.0 . If/when this changes,
-it will be noted in the changelog, and the crate semver will be updated. So
-downstream projects should depend upon e.g. `spake2 = "0.2"` to avoid picking
-up new versions that would require a newer compiler.
+The MSRV (Minimum Supported Rust Version) for `srp` is 1.32.0. The MSRV for
+`spake2` is 1.36.0 . If/when these change, it will be noted in the changelog,
+and the crate semvers will be updated. So downstream projects should depend
+upon e.g. `spake2 = "0.3"` to avoid picking up new versions that would
+require a newer compiler.
 
 SRP-v0.4.1 actually works with rustc-1.31.1, but this will probably be
 changed in the next release.
 
 SPAKE2 required rustc-1.32 beginning with spake2-v0.2.0 .
+
+SPAKE2 started requiring rustc-1.36 beginning with spake2-v0.3.0 .
 
 Our CI scripts check all builds against a pinned version of rustc to test the
 intended MSRV. Sometimes upstream dependencies make surprising changes that

--- a/spake2/Cargo.toml
+++ b/spake2/Cargo.toml
@@ -26,8 +26,8 @@ is-it-maintained-issue-resolution = { repository = "RustCrypto/PAKEs" }
 is-it-maintained-open-issues = { repository = "RustCrypto/PAKEs" }
 
 [dependencies]
-curve25519-dalek = "1.2"
-rand = "0.6"
+curve25519-dalek = "2.0"
+rand_core = { version = "0.5", default-features = false, features = ["getrandom"] }
 sha2 = "0.8"
 hkdf = "0.8"
 hex = "0.4"

--- a/spake2/src/lib.rs
+++ b/spake2/src/lib.rs
@@ -293,7 +293,7 @@ use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::edwards::EdwardsPoint as c2_Element;
 use curve25519_dalek::scalar::Scalar as c2_Scalar;
 use hkdf::Hkdf;
-use rand::{rngs::OsRng, CryptoRng, Rng};
+use rand_core::{CryptoRng, OsRng, RngCore};
 use sha2::{Digest, Sha256};
 use std::fmt;
 use std::ops::Deref;
@@ -357,7 +357,7 @@ pub trait Group {
     fn hash_to_scalar(s: &[u8]) -> Self::Scalar;
     fn random_scalar<T>(cspring: &mut T) -> Self::Scalar
     where
-        T: Rng + CryptoRng;
+        T: RngCore + CryptoRng;
     fn scalar_neg(s: &Self::Scalar) -> Self::Scalar;
     fn element_to_bytes(e: &Self::Element) -> Vec<u8>;
     fn bytes_to_element(b: &[u8]) -> Option<Self::Element>;
@@ -423,7 +423,7 @@ impl Group for Ed25519Group {
     }
     fn random_scalar<T>(cspring: &mut T) -> c2_Scalar
     where
-        T: Rng + CryptoRng,
+        T: RngCore + CryptoRng,
     {
         c2_Scalar::random(cspring)
     }
@@ -704,19 +704,19 @@ impl<G: Group> SPAKE2<G> {
     }
 
     pub fn start_a(password: &Password, id_a: &Identity, id_b: &Identity) -> (SPAKE2<G>, Vec<u8>) {
-        let mut cspring: OsRng = OsRng::new().unwrap();
+        let mut cspring = OsRng;
         let xy_scalar: G::Scalar = G::random_scalar(&mut cspring);
         Self::start_a_internal(&password, &id_a, &id_b, xy_scalar)
     }
 
     pub fn start_b(password: &Password, id_a: &Identity, id_b: &Identity) -> (SPAKE2<G>, Vec<u8>) {
-        let mut cspring: OsRng = OsRng::new().unwrap();
+        let mut cspring = OsRng;
         let xy_scalar: G::Scalar = G::random_scalar(&mut cspring);
         Self::start_b_internal(&password, &id_a, &id_b, xy_scalar)
     }
 
     pub fn start_symmetric(password: &Password, id_s: &Identity) -> (SPAKE2<G>, Vec<u8>) {
-        let mut cspring: OsRng = OsRng::new().unwrap();
+        let mut cspring = OsRng;
         let xy_scalar: G::Scalar = G::random_scalar(&mut cspring);
         Self::start_symmetric_internal(&password, &id_s, xy_scalar)
     }

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -17,7 +17,7 @@ digest = "0.8"
 lazy_static = "1.2"
 
 [dev-dependencies]
-rand = "0.6"
+rand_core = { version = "0.5", default-features = false, features = ["getrandom"] }
 sha2 = "0.8"
 sha-1 = "0.8"
 

--- a/srp/tests/mod.rs
+++ b/srp/tests/mod.rs
@@ -1,5 +1,4 @@
-use rand;
-use rand::RngCore;
+use rand_core::{OsRng, RngCore};
 use sha2::Sha256;
 
 use srp::client::{srp_private_key, SrpClient};
@@ -7,17 +6,16 @@ use srp::groups::G_2048;
 use srp::server::{SrpServer, UserRecord};
 
 fn auth_test(reg_pwd: &[u8], auth_pwd: &[u8]) {
-    let mut rng = rand::rngs::OsRng::new().unwrap();
     let username = b"alice";
 
     // Client instance creation
     let mut a = [0u8; 64];
-    rng.fill_bytes(&mut a);
+    OsRng.fill_bytes(&mut a);
     let client = SrpClient::<Sha256>::new(&a, &G_2048);
 
     // Registration
     let mut salt = [0u8; 16];
-    rng.fill_bytes(&mut salt);
+    OsRng.fill_bytes(&mut salt);
     let reg_priv_key = srp_private_key::<Sha256>(username, reg_pwd, &salt);
     let verif = client.get_password_verifier(&reg_priv_key);
 
@@ -31,7 +29,7 @@ fn auth_test(reg_pwd: &[u8], auth_pwd: &[u8]) {
         verifier: &verif,
     };
     let mut b = [0u8; 64];
-    rng.fill_bytes(&mut b);
+    OsRng.fill_bytes(&mut b);
     let server = SrpServer::<Sha256>::new(&user, &a_pub, &b, &G_2048).unwrap();
     let (salt, b_pub) = (&user.salt, server.get_b_pub());
 


### PR DESCRIPTION
This now only needs `rand_core`, not the full `rand` hierarchy, because the latest `rand_core` includes a basic `OsRng` function.

The latest curve25519-dalek uses `zeroize`, which uses the `alloc` feature, which raises the `spake2` MSRV to rustc-1.36 .

It upgrades `srp` to use `rand_core` as well. The `srp` MSRV remains at rustc-1.32 .

I update the travis config to exercise 1.36, because it seemed too hard to make it test srp/spake2 with different versions.

fixes #21

@newpavlov you might want to defer this until you made the SRP API changes you mentioned in #21 
