### PR TITLE
srp: fix typos in docstrings

### DIFF
--- a/srp/src/client.rs
+++ b/srp/src/client.rs
@@ -48,7 +48,7 @@
 //! authenticated cipher mode).
 //!
 //! For user registration on the server first generate salt (e.g. 32 bytes long)
-//! and get password verifier which depends on private key. Send useranme, salt
+//! and get password verifier which depends on private key. Send username, salt
 //! and password verifier over protected channel to protect against
 //! Man-in-the-middle (MITM) attack for registration.
 //!

--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -10,7 +10,7 @@
 //! Compatibility with over implementations was not yet tested.
 //!
 //! # Usage
-//! Add `srp` dependecy to your `Cargo.toml`:
+//! Add `srp` dependency to your `Cargo.toml`:
 //!
 //! ```toml
 //! [dependencies]
@@ -27,7 +27,7 @@
 //! [`server`](server/index.html) modules.
 //!
 //! # Algorithm description
-//! Here we briefly describe implemented algroithm. For additionall information
+//! Here we briefly describe implemented algorithm. For additional information
 //! refer to SRP literature. All arithmetic is done modulo `N`, where `N` is a
 //! large safe prime (`N = 2q+1`, where `q` is prime). Additionally `g` MUST be
 //! a generator modulo `N`. It's STRONGLY recommended to use SRP parameters
@@ -43,8 +43,7 @@
 //! |`M1 = H(A ‖ B ‖ K)`     |     — `M1` —>     | (verify `M1`)                   |
 //! |(verify `M2`)           |    <— `M2` —      | `M2 = H(A ‖ M1 ‖ K)`            |
 //!
-//! Variables and notations have the following
-//! meaning:
+//! Variables and notations have the following meaning:
 //!
 //! - `I` — user identity (username)
 //! - `P` — user password

--- a/srp/src/server.rs
+++ b/srp/src/server.rs
@@ -22,7 +22,7 @@
 //! conn.reply_to_handshake(&user.salt, b_pub);
 //! ```
 //!
-//! And finally recieve user proof, verify it and send server proof in the
+//! And finally receive user proof, verify it and send server proof in the
 //! reply:
 //!
 //! ```ignore


### PR DESCRIPTION
This fixes a few minor typos in docstrings.