### PR TITLE
Fix typo over -> other

### DIFF
--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -7,7 +7,7 @@
 //! algorithm for private key computation instead of method described in the
 //! SRP literature.
 //!
-//! Compatibility with over implementations was not yet tested.
+//! Compatibility with other implementations was not yet tested.
 //!
 //! # Usage
 //! Add `srp` dependency to your `Cargo.toml`:


### PR DESCRIPTION
There is a typo in the documentation of the `srp` crate.