### PR TITLE
srp v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "srp"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "digest 0.10.1",
  "generic-array 0.14.4",

--- a/srp/CHANGELOG.md
+++ b/srp/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.6.0 (2022-01-22)
+### Changed
+- Use `modpow` for constant time modular exponentation ([#78])
+- Rebuild library ([#79])
+
+[#78]: https://github.com/RustCrypto/PAKEs/pull/78
+[#79]: https://github.com/RustCrypto/PAKEs/pull/79
+
+## 0.5.0 (2020-10-07)
+
+## 0.4.3 (2019-11-07)
+
+## 0.4.2 (2019-11-06)
+
+## 0.4.1 (2019-11-07)
+
+## 0.4.0 (2018-12-20)
+
+## 0.3.0 (2018-10-22)
+
+## 0.2.5 (2018-04-14)
+
+## 0.2.4 (2017-11-01)
+
+## 0.2.3 (2017-08-17)
+
+## 0.2.2 (2017-08-14)
+
+## 0.2.1 (2017-08-14)
+
+## 0.2.0 (2017-08-14)
+
+## 0.1.1 (2017-08-13)
+
+## 0.1.0 (2017-08-13)

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srp"
-version = "0.6.0-pre"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Secure Remote Password (SRP) protocol implementation"

--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! srp = "0.4"
+//! srp = "0.6"
 //! ```
 //!
 //! Next read documentation for [`client`](client/index.html) and


### PR DESCRIPTION
### Changed
- Use `modpow` for constant time modular exponentation ([#78])
- Rebuild library ([#79])

[#78]: https://github.com/RustCrypto/PAKEs/pull/78
[#79]: https://github.com/RustCrypto/PAKEs/pull/79