### PR TITLE
spake2: bump `curve25519-dalek` to v3.0; `rand_core` => v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -41,7 +41,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -51,25 +51,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "cc"
-version = "1.0.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clear_on_drop"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "cloudabi"
@@ -95,7 +80,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -104,30 +89,21 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
  "subtle",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "1.2.6"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d59fed08e452f286b251f88b2fc64a01f50a7b263aa09557ad7285d9e7fa"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "clear_on_drop",
- "digest 0.8.1",
- "rand_core 0.3.1",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -136,7 +112,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -147,7 +123,7 @@ checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
  "block-buffer 0.10.0",
  "crypto-common",
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -158,21 +134,23 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -300,6 +278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,7 +401,7 @@ dependencies = [
  "hex",
  "hkdf",
  "num-bigint",
- "rand",
+ "rand_core 0.5.1",
  "sha2 0.9.8",
 ]
 
@@ -423,7 +410,7 @@ name = "srp"
 version = "0.6.0"
 dependencies = [
  "digest 0.10.1",
- "generic-array 0.14.5",
+ "generic-array",
  "hex-literal",
  "lazy_static",
  "num-bigint",
@@ -453,6 +440,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,3 +466,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zeroize"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"

--- a/spake2/Cargo.toml
+++ b/spake2/Cargo.toml
@@ -5,24 +5,18 @@ authors = ["Brian Warner <warner@lothar.com>"]
 description = "The SPAKE2 password-authenticated key-exchange algorithm."
 documentation = "https://docs.rs/spake2"
 homepage = "https://github.com/RustCrypto/PAKEs"
-repository = "https://github.com/RustCrypto/PAKEs"
+repository = "https://github.com/RustCrypto/PAKEs/tree/master/spake2"
 license = "MIT OR Apache-2.0"
 keywords = ["crypto", "pake", "authentication"]
 categories = ["cryptography", "authentication"]
 exclude = [".gitignore"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 
-[package.metadata.release]
-tag-prefix = "spake2-v"
-tag-message = "(cargo-release) spake2-v{{version}}"
-pre-release-commit-message = "(cargo-release) spake2-v{{version}}"
-pro-release-commit-message = "(cargo-release) start next development iteration spake2-v{{version}}"
-
 [dependencies]
-curve25519-dalek = "1.2"
-rand = "0.6"
+curve25519-dalek = "3"
+rand_core = { version = "0.5", default-features = false, features = ["getrandom"] }
 sha2 = "0.9"
 hkdf = "0.11"
 hex = "0.4"

--- a/spake2/src/lib.rs
+++ b/spake2/src/lib.rs
@@ -222,7 +222,7 @@ use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::edwards::EdwardsPoint as c2_Element;
 use curve25519_dalek::scalar::Scalar as c2_Scalar;
 use hkdf::Hkdf;
-use rand::{rngs::OsRng, CryptoRng, Rng};
+use rand_core::{CryptoRng, OsRng, RngCore};
 use sha2::{Digest, Sha256};
 use std::fmt;
 use std::ops::Deref;
@@ -286,7 +286,7 @@ pub trait Group {
     fn hash_to_scalar(s: &[u8]) -> Self::Scalar;
     fn random_scalar<T>(cspring: &mut T) -> Self::Scalar
     where
-        T: Rng + CryptoRng;
+        T: RngCore + CryptoRng;
     fn scalar_neg(s: &Self::Scalar) -> Self::Scalar;
     fn element_to_bytes(e: &Self::Element) -> Vec<u8>;
     fn bytes_to_element(b: &[u8]) -> Option<Self::Element>;
@@ -352,7 +352,7 @@ impl Group for Ed25519Group {
     }
     fn random_scalar<T>(cspring: &mut T) -> c2_Scalar
     where
-        T: Rng + CryptoRng,
+        T: RngCore + CryptoRng,
     {
         c2_Scalar::random(cspring)
     }
@@ -632,19 +632,19 @@ impl<G: Group> SPAKE2<G> {
     }
 
     pub fn start_a(password: &Password, id_a: &Identity, id_b: &Identity) -> (SPAKE2<G>, Vec<u8>) {
-        let mut cspring: OsRng = OsRng::new().unwrap();
+        let mut cspring = OsRng;
         let xy_scalar: G::Scalar = G::random_scalar(&mut cspring);
         Self::start_a_internal(password, id_a, id_b, xy_scalar)
     }
 
     pub fn start_b(password: &Password, id_a: &Identity, id_b: &Identity) -> (SPAKE2<G>, Vec<u8>) {
-        let mut cspring: OsRng = OsRng::new().unwrap();
+        let mut cspring = OsRng;
         let xy_scalar: G::Scalar = G::random_scalar(&mut cspring);
         Self::start_b_internal(password, id_a, id_b, xy_scalar)
     }
 
     pub fn start_symmetric(password: &Password, id_s: &Identity) -> (SPAKE2<G>, Vec<u8>) {
-        let mut cspring: OsRng = OsRng::new().unwrap();
+        let mut cspring = OsRng;
         let xy_scalar: G::Scalar = G::random_scalar(&mut cspring);
         Self::start_symmetric_internal(password, id_s, xy_scalar)
     }


### PR DESCRIPTION
This is a continuation of #33.

It bumps `curve25519-dalek` to the latest stable release and replaces the `rand` crate with the version of `rand_core` which is compatible with `curve25519-dalek`: v0.5 (which is still a version behind)