### PR TITLE
spake2: initial `no_std` support

### DIFF
--- a/.github/workflows/spake2.yml
+++ b/.github/workflows/spake2.yml
@@ -17,6 +17,25 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.56.0 # MSRV
+          - stable
+        target:
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo build --target ${{ matrix.target }} --release
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/spake2/Cargo.toml
+++ b/spake2/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-curve25519-dalek = "3"
+curve25519-dalek = { version = "3", default-features = false, features = ["u64_backend"] }
 rand_core = { version = "0.5", default-features = false, features = ["getrandom"] }
 sha2 = "0.10"
 hkdf = "0.12"
@@ -24,6 +24,10 @@ hkdf = "0.12"
 bencher = "0.1"
 hex = "0.4"
 num-bigint = "0.4"
+
+[features]
+default = []
+std = []
 
 [[bench]]
 name = "spake2"

--- a/spake2/src/lib.rs
+++ b/spake2/src/lib.rs
@@ -1,7 +1,8 @@
-#![forbid(unsafe_code)]
-#![warn(rust_2018_idioms, unused_qualifications)]
+#![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![doc = include_str!("../README.md")]
+#![forbid(unsafe_code)]
+#![warn(rust_2018_idioms, unused_qualifications)]
 
 //! # Usage
 //!
@@ -217,6 +218,15 @@
 //! [6]: http://eprint.iacr.org/2003/038.pdf "Pretty-Simple Password-Authenticated Key-Exchange Under Standard Assumptions"
 //! [7]: https://moderncrypto.org/mail-archive/curves/2015/000419.html "PAKE questions"
 
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+#[cfg_attr(test, macro_use)]
+extern crate std;
+
+use alloc::vec::Vec;
 use core::{fmt, ops::Deref, str};
 use curve25519_dalek::{
     constants::ED25519_BASEPOINT_POINT,

--- a/spake2/src/tests.rs
+++ b/spake2/src/tests.rs
@@ -2,6 +2,9 @@
 //! spake2.test.test_compat.SPAKE2.test_asymmetric . The python test passes a
 //! deterministic RNG (used only for tests, of course) into the per-Group
 //! "random_scalar()" function, which results in some particular scalar.
+
+#![cfg(feature = "std")]
+
 use super::*;
 use curve25519_dalek::constants::ED25519_BASEPOINT_POINT;
 


### PR DESCRIPTION
Still has a hard dependency on `alloc`, and with the current hard dependency on `getrandom` also limited platform support