### PR TITLE
spake2: `getrandom` feature

### DIFF
--- a/.github/workflows/spake2.yml
+++ b/.github/workflows/spake2.yml
@@ -25,6 +25,7 @@ jobs:
           - 1.56.0 # MSRV
           - stable
         target:
+          - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v1
@@ -34,7 +35,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo build --target ${{ matrix.target }} --release
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
 
   test:
     runs-on: ubuntu-latest
@@ -51,3 +52,4 @@ jobs:
           override: true
           profile: minimal
       - run: cargo test --release
+      - run: cargo test --release --all-features

--- a/spake2/Cargo.toml
+++ b/spake2/Cargo.toml
@@ -16,9 +16,9 @@ rust-version = "1.56"
 
 [dependencies]
 curve25519-dalek = { version = "3", default-features = false, features = ["u64_backend"] }
-rand_core = { version = "0.5", default-features = false, features = ["getrandom"] }
-sha2 = "0.10"
-hkdf = "0.12"
+rand_core = { version = "0.5", default-features = false }
+sha2 = { version = "0.10", default-features = false }
+hkdf = { version = "0.12", default-features = false }
 
 [dev-dependencies]
 bencher = "0.1"
@@ -26,8 +26,13 @@ hex = "0.4"
 num-bigint = "0.4"
 
 [features]
-default = []
+default = ["getrandom"]
+getrandom = ["rand_core/getrandom"]
 std = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [[bench]]
 name = "spake2"


### PR DESCRIPTION
Makes `getrandom` an optional on-by-default feature

Adds CI for `thumbv7em-none-eabi` targets