### PR TITLE
spake2: capitalization and doc fixes

### DIFF
--- a/spake2/benches/spake2.rs
+++ b/spake2/benches/spake2.rs
@@ -1,10 +1,10 @@
 use bencher::Bencher;
 use bencher::{benchmark_group, benchmark_main};
-use spake2::{Ed25519Group, Identity, Password, SPAKE2};
+use spake2::{Ed25519Group, Identity, Password, Spake2};
 
 fn spake2_start(bench: &mut Bencher) {
     bench.iter(|| {
-        let (_, _) = SPAKE2::<Ed25519Group>::start_a(
+        let (_, _) = Spake2::<Ed25519Group>::start_a(
             &Password::new(b"password"),
             &Identity::new(b"idA"),
             &Identity::new(b"idB"),
@@ -31,14 +31,14 @@ fn spake2_finish(bench: &mut Bencher) {
 */
 
 fn spake2_start_and_finish(bench: &mut Bencher) {
-    let (_, msg2) = SPAKE2::<Ed25519Group>::start_b(
+    let (_, msg2) = Spake2::<Ed25519Group>::start_b(
         &Password::new(b"password"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
     );
     let msg2_slice = msg2.as_slice();
     bench.iter(|| {
-        let (s1, _) = SPAKE2::<Ed25519Group>::start_a(
+        let (s1, _) = Spake2::<Ed25519Group>::start_a(
             &Password::new(b"password"),
             &Identity::new(b"idA"),
             &Identity::new(b"idB"),

--- a/spake2/src/tests.rs
+++ b/spake2/src/tests.rs
@@ -61,13 +61,13 @@ fn test_password_to_scalar() {
 
 #[test]
 fn test_sizes() {
-    let (s1, msg1) = SPAKE2::<Ed25519Group>::start_a(
+    let (s1, msg1) = Spake2::<Ed25519Group>::start_a(
         &Password::new(b"password"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
     );
     assert_eq!(msg1.len(), 1 + 32);
-    let (s2, msg2) = SPAKE2::<Ed25519Group>::start_b(
+    let (s2, msg2) = Spake2::<Ed25519Group>::start_b(
         &Password::new(b"password"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
@@ -78,12 +78,12 @@ fn test_sizes() {
     assert_eq!(key1.len(), 32);
     assert_eq!(key2.len(), 32);
 
-    let (s1, msg1) = SPAKE2::<Ed25519Group>::start_symmetric(
+    let (s1, msg1) = Spake2::<Ed25519Group>::start_symmetric(
         &Password::new(b"password"),
         &Identity::new(b"idS"),
     );
     assert_eq!(msg1.len(), 1 + 32);
-    let (s2, msg2) = SPAKE2::<Ed25519Group>::start_symmetric(
+    let (s2, msg2) = Spake2::<Ed25519Group>::start_symmetric(
         &Password::new(b"password"),
         &Identity::new(b"idS"),
     );
@@ -135,7 +135,7 @@ fn test_asymmetric() {
 
     println!("scalar_a is {}", hex::encode(scalar_a.as_bytes()));
 
-    let (s1, msg1) = SPAKE2::<Ed25519Group>::start_a_internal(
+    let (s1, msg1) = Spake2::<Ed25519Group>::start_a_internal(
         &Password::new(b"password"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
@@ -159,7 +159,7 @@ fn test_asymmetric() {
     );
     assert_eq!(hex::encode(&msg1), expected_msg1);
 
-    let (s2, msg2) = SPAKE2::<Ed25519Group>::start_b_internal(
+    let (s2, msg2) = Spake2::<Ed25519Group>::start_b_internal(
         &Password::new(b"password"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
@@ -182,7 +182,7 @@ fn test_asymmetric() {
 
 #[test]
 fn test_debug() {
-    let (s1, _msg1) = SPAKE2::<Ed25519Group>::start_a(
+    let (s1, _msg1) = Spake2::<Ed25519Group>::start_a(
         &Password::new(b"password"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
@@ -193,7 +193,7 @@ fn test_debug() {
         "SPAKE2 { group: \"Ed25519\", side: A, idA: (s=idA), idB: (s=idB), idS: (s=) }"
     );
 
-    let (s2, _msg1) = SPAKE2::<Ed25519Group>::start_symmetric(
+    let (s2, _msg1) = Spake2::<Ed25519Group>::start_symmetric(
         &Password::new(b"password"),
         &Identity::new(b"idS"),
     );

--- a/spake2/tests/spake2.rs
+++ b/spake2/tests/spake2.rs
@@ -1,13 +1,13 @@
-use spake2::{Ed25519Group, ErrorType, Identity, Password, SPAKEErr, SPAKE2};
+use spake2::{Ed25519Group, Error, Identity, Password, Spake2};
 
 #[test]
 fn test_basic() {
-    let (s1, msg1) = SPAKE2::<Ed25519Group>::start_a(
+    let (s1, msg1) = Spake2::<Ed25519Group>::start_a(
         &Password::new(b"password"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
     );
-    let (s2, msg2) = SPAKE2::<Ed25519Group>::start_b(
+    let (s2, msg2) = Spake2::<Ed25519Group>::start_b(
         &Password::new(b"password"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
@@ -19,12 +19,12 @@ fn test_basic() {
 
 #[test]
 fn test_mismatch() {
-    let (s1, msg1) = SPAKE2::<Ed25519Group>::start_a(
+    let (s1, msg1) = Spake2::<Ed25519Group>::start_a(
         &Password::new(b"password"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
     );
-    let (s2, msg2) = SPAKE2::<Ed25519Group>::start_b(
+    let (s2, msg2) = Spake2::<Ed25519Group>::start_b(
         &Password::new(b"password2"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
@@ -36,23 +36,18 @@ fn test_mismatch() {
 
 #[test]
 fn test_reflected_message() {
-    let (s1, msg1) = SPAKE2::<Ed25519Group>::start_a(
+    let (s1, msg1) = Spake2::<Ed25519Group>::start_a(
         &Password::new(b"password"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
     );
     let r = s1.finish(msg1.as_slice());
-    assert_eq!(
-        r.unwrap_err(),
-        SPAKEErr {
-            kind: ErrorType::BadSide,
-        }
-    );
+    assert_eq!(r.unwrap_err(), Error::BadSide);
 }
 
 #[test]
 fn test_bad_length() {
-    let (s1, msg1) = SPAKE2::<Ed25519Group>::start_a(
+    let (s1, msg1) = Spake2::<Ed25519Group>::start_a(
         &Password::new(b"password"),
         &Identity::new(b"idA"),
         &Identity::new(b"idB"),
@@ -60,21 +55,16 @@ fn test_bad_length() {
     let mut msg2 = Vec::<u8>::with_capacity(msg1.len() + 1);
     msg2.resize(msg1.len() + 1, 0u8);
     let r = s1.finish(&msg2);
-    assert_eq!(
-        r.unwrap_err(),
-        SPAKEErr {
-            kind: ErrorType::WrongLength,
-        }
-    );
+    assert_eq!(r.unwrap_err(), Error::WrongLength);
 }
 
 #[test]
 fn test_basic_symmetric() {
-    let (s1, msg1) = SPAKE2::<Ed25519Group>::start_symmetric(
+    let (s1, msg1) = Spake2::<Ed25519Group>::start_symmetric(
         &Password::new(b"password"),
         &Identity::new(b"idS"),
     );
-    let (s2, msg2) = SPAKE2::<Ed25519Group>::start_symmetric(
+    let (s2, msg2) = Spake2::<Ed25519Group>::start_symmetric(
         &Password::new(b"password"),
         &Identity::new(b"idS"),
     );


### PR DESCRIPTION
Renames the following:

- `SPAKE2` => `Spake2`
- `SPAKEErr` -> `Error`

Additionally lints for `missing_docs` and adds preliminary documentation for all types and methods which previously had none.