### PR TITLE
spake2 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "spake2"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "bencher",
  "curve25519-dalek",

--- a/spake2/CHANGELOG.md
+++ b/spake2/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.3.0 (2022-01-22)
+### Added
+- Initial `no_std` support ([#87])
+- `getrandom` feature ([#88])
+
+### Changed
+- 2021 edition upgrade; MSRV 1.56 ([#80])
+- Bump `curve25519-dalek` to v3.0  ([#85])
+- Replace `rand` with `rand_core` v0.5 ([#85])
+- Bump `hkdf` to v0.12 ([#86])
+- Bump `sha2` to v0.10 ([#86])
+- Renamed `SPAKE2` => `Spake2` ([#89])
+- Renamed `SPAKEErr` => `Error` ([#89])
+
+[#80]: https://github.com/RustCrypto/PAKEs/pull/80
+[#85]: https://github.com/RustCrypto/PAKEs/pull/85
+[#86]: https://github.com/RustCrypto/PAKEs/pull/86
+[#87]: https://github.com/RustCrypto/PAKEs/pull/87
+[#88]: https://github.com/RustCrypto/PAKEs/pull/88
+[#89]: https://github.com/RustCrypto/PAKEs/pull/89
+
+## 0.2.0 (2018-12-20)
+
+## 0.1.1 (2018-10-16)
+
+## 0.1.0 (2018-08-21)
+
+## 0.0.9 (2018-08-21)
+
+## 0.0.8 (2018-05-26)
+
+## 0.0.7 (2018-05-25)
+
+## 0.0.6 (2018-05-23)
+
+## 0.0.5 (2018-04-29)
+
+## 0.0.4 (2018-01-28)
+
+## 0.0.3 (2017-11-29)
+
+## 0.0.2 (2017-09-21)
+
+## 0.0.1 (2017-08-01)

--- a/spake2/Cargo.toml
+++ b/spake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spake2"
-version = "0.3.0-pre"
+version = "0.3.0"
 authors = ["Brian Warner <warner@lothar.com>"]
 description = "The SPAKE2 password-authenticated key-exchange algorithm."
 documentation = "https://docs.rs/spake2"


### PR DESCRIPTION
### Added
- Initial `no_std` support ([#87])
- `getrandom` feature ([#88])

### Changed
- 2021 edition upgrade; MSRV 1.56 ([#80])
- Bump `curve25519-dalek` to v3.0  ([#85])
- Replace `rand` with `rand_core` v0.5 ([#85])
- Bump `hkdf` to v0.12 ([#86])
- Bump `sha2` to v0.10 ([#86])
- Renamed `SPAKE2` => `Spake2` ([#89])
- Renamed `SPAKEErr` => `Error` ([#89])

[#80]: https://github.com/RustCrypto/PAKEs/pull/80
[#85]: https://github.com/RustCrypto/PAKEs/pull/85
[#86]: https://github.com/RustCrypto/PAKEs/pull/86
[#87]: https://github.com/RustCrypto/PAKEs/pull/87
[#88]: https://github.com/RustCrypto/PAKEs/pull/88
[#89]: https://github.com/RustCrypto/PAKEs/pull/89