### PR TITLE
srp: switch from `sha-1` to `sha1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,10 +332,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
+name = "sha1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "04cc229fb94bcb689ffc39bd4ded842f6ff76885efede7c6d1ffb62582878bea"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -377,7 +377,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rand",
- "sha-1",
+ "sha1",
  "sha2",
  "subtle",
 ]

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -20,8 +20,8 @@ lazy_static = "1.2"
 subtle = "2.4"
 
 [dev-dependencies]
-rand = "0.6"
-sha2 = "0.10"
-sha-1 = "0.10"
-num-traits = "0.2"
 hex-literal = "0.3"
+num-traits = "0.2"
+rand = "0.6"
+sha1 = "0.10"
+sha2 = "0.10"


### PR DESCRIPTION
The former is deprecated. Note: `dev-dependencies` only