### PR TITLE
spake2 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "spake2"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "bencher",
  "curve25519-dalek",

--- a/spake2/CHANGELOG.md
+++ b/spake2/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2023-07-23)
+### Changed
+- Move IDs to relevant `Side` enum variants ([#114])
+- MSRV 1.60 ([#115])
+- Bump `curve25519-dalek` to v4.0 release ([#138])
+
+[#114]: https://github.com/RustCrypto/PAKEs/pull/114
+[#115]: https://github.com/RustCrypto/PAKEs/pull/115
+[#138]: https://github.com/RustCrypto/PAKEs/pull/138
+
 ## 0.3.1 (2022-01-22)
 ### Changed
 - Refactor internals ([#91])

--- a/spake2/Cargo.toml
+++ b/spake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spake2"
-version = "0.4.0-pre"
+version = "0.4.0"
 authors = ["Brian Warner <warner@lothar.com>"]
 description = "The SPAKE2 password-authenticated key-exchange algorithm."
 documentation = "https://docs.rs/spake2"
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-curve25519-dalek = { version = "=4.0.0", default-features = false, features = ["rand_core"] }
+curve25519-dalek = { version = "4", default-features = false, features = ["rand_core"] }
 rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 hkdf = { version = "0.12", default-features = false }

--- a/spake2/LICENSE-MIT
+++ b/spake2/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Brian Warner
+Copyright (c) 2017-2023 Brian Warner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spake2/src/lib.rs
+++ b/spake2/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -312,7 +312,6 @@ impl<G: Group> Spake2<G> {
     ///
     /// Uses the system RNG.
     #[cfg(feature = "getrandom")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "getrandom")))]
     pub fn start_a(password: &Password, id_a: &Identity, id_b: &Identity) -> (Spake2<G>, Vec<u8>) {
         Self::start_a_with_rng(password, id_a, id_b, OsRng)
     }
@@ -321,7 +320,6 @@ impl<G: Group> Spake2<G> {
     ///
     /// Uses the system RNG.
     #[cfg(feature = "getrandom")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "getrandom")))]
     pub fn start_b(password: &Password, id_a: &Identity, id_b: &Identity) -> (Spake2<G>, Vec<u8>) {
         Self::start_b_with_rng(password, id_a, id_b, OsRng)
     }
@@ -330,7 +328,6 @@ impl<G: Group> Spake2<G> {
     ///
     /// Uses the system RNG.
     #[cfg(feature = "getrandom")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "getrandom")))]
     pub fn start_symmetric(password: &Password, id_s: &Identity) -> (Spake2<G>, Vec<u8>) {
         Self::start_symmetric_with_rng(password, id_s, OsRng)
     }


### PR DESCRIPTION
### Changed
- Move IDs to relevant `Side` enum variants ([#114])
- MSRV 1.60 ([#115])
- Bump `curve25519-dalek` to v4.0 release ([#138])

[#114]: https://github.com/RustCrypto/PAKEs/pull/114
[#115]: https://github.com/RustCrypto/PAKEs/pull/115
[#138]: https://github.com/RustCrypto/PAKEs/pull/138