### PR TITLE
Fix `clippy` warnings and bump `srp` and `aucpace` MSRV to `1.61`

### DIFF
--- a/.github/workflows/aucpace.yml
+++ b/.github/workflows/aucpace.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.62.1 # MSRV
+          - 1.61.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.62.1 # MSRV
+          - 1.61.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/aucpace.yml
+++ b/.github/workflows/aucpace.yml
@@ -3,10 +3,12 @@ name: aucpace
 on:
   pull_request:
     paths:
+      - ".github/workflows/aucpace.yml"
       - "aucpace/**"
       - "Cargo.*"
   push:
-    branches: master
+    branches:
+      - master
 
 defaults:
   run:
@@ -22,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.62.1 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -40,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.62.1 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/aucpace.yml
+++ b/.github/workflows/aucpace.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.61.0 # MSRV
+          - 1.61 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.61.0 # MSRV
+          - 1.61 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/srp.yml
+++ b/.github/workflows/srp.yml
@@ -3,10 +3,12 @@ name: srp
 on:
   pull_request:
     paths:
+      - ".github/workflows/srp.yml"
       - "srp/**"
       - "Cargo.*"
   push:
-    branches: master
+    branches:
+      - master
 
 defaults:
   run:
@@ -22,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.61.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/srp.yml
+++ b/.github/workflows/srp.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.61.0 # MSRV
+          - 1.61 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+          components: clippy
       - run: cargo clippy --all --all-features -- -D warnings
 
   rustfmt:

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -13,18 +13,13 @@ on:
 jobs:
   clippy:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.60.0 # MSRV
-          - stable
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           components: clippy
-      - run: cargo clippy --all --all-features -- -D warnings
+      - run: cargo clippy --all -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -5,20 +5,25 @@ on:
     paths-ignore:
       - README.md
   push:
-    branches: master
+    branches:
+      - master
     paths-ignore:
       - README.md
 
 jobs:
   clippy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.60.0 # MSRV
+          - stable
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.60.0 # MSRV
-          components: clippy
-      - run: cargo clippy --all -- -D warnings
+          toolchain: ${{ matrix.rust }}
+      - run: cargo clippy --all --all-features -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aucpace"
-version = "0.1.1"
+version = "0.2.0-pre"
 dependencies = [
  "bincode",
  "curve25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "srp"
-version = "0.6.0"
+version = "0.7.0-pre"
 dependencies = [
  "digest",
  "generic-array",

--- a/aucpace/Cargo.toml
+++ b/aucpace/Cargo.toml
@@ -12,16 +12,25 @@ categories = ["cryptography", "authentication"]
 exclude = [".gitignore"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.61"
 
 [dependencies]
-curve25519-dalek = { version = "4", default-features = false, features = ["digest", "rand_core"] }
-password-hash = { version = "0.5", default-features = false, features = ["rand_core"] }
+curve25519-dalek = { version = "4", default-features = false, features = [
+    "digest",
+    "rand_core",
+] }
+password-hash = { version = "0.5", default-features = false, features = [
+    "rand_core",
+] }
 rand_core = { version = "0.6", default-features = false }
-serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
+serde = { version = "1", default-features = false, optional = true, features = [
+    "derive",
+] }
 serde-byte-array = { version = "0.1", optional = true }
 subtle = { version = "2.4", default-features = false }
-scrypt = { version = "0.11", default-features = false, optional = true, features = ["simple"] }
+scrypt = { version = "0.11", default-features = false, optional = true, features = [
+    "simple",
+] }
 sha2 = { version = "0.10", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/aucpace/Cargo.toml
+++ b/aucpace/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "authentication"]
 exclude = [".gitignore"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.62.1"
 
 [dependencies]
 curve25519-dalek = { version = "4", default-features = false, features = ["digest", "rand_core"] }

--- a/aucpace/Cargo.toml
+++ b/aucpace/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "authentication"]
 exclude = [".gitignore"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.62.1"
+rust-version = "1.61.0"
 
 [dependencies]
 curve25519-dalek = { version = "4", default-features = false, features = ["digest", "rand_core"] }

--- a/aucpace/Cargo.toml
+++ b/aucpace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aucpace"
-version = "0.1.1"
+version = "0.2.0-pre"
 authors = ["Sam Leonard <tritoke@protonmail.com>"]
 description = "AuCPace protocol implementation"
 documentation = "https://docs.rs/aucpace"

--- a/aucpace/README.md
+++ b/aucpace/README.md
@@ -56,7 +56,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.61.0** or higher.
+Rust **1.61** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.

--- a/aucpace/README.md
+++ b/aucpace/README.md
@@ -56,7 +56,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.60** or higher.
+Rust **1.62.1** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.

--- a/aucpace/README.md
+++ b/aucpace/README.md
@@ -56,7 +56,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.62.1** or higher.
+Rust **1.61.0** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.

--- a/aucpace/examples/key_agreement.rs
+++ b/aucpace/examples/key_agreement.rs
@@ -31,8 +31,8 @@ macro_rules! recv {
 
 fn main() -> Result<()> {
     // example username and password, never user these...
-    const USERNAME: &'static [u8] = b"jlpicard_1701";
-    const PASSWORD: &'static [u8] = b"g04tEd_c4pT41N";
+    const USERNAME: &[u8] = b"jlpicard_1701";
+    const PASSWORD: &[u8] = b"g04tEd_c4pT41N";
 
     // the server socket address to bind to
     let server_socket: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 25519);
@@ -286,6 +286,7 @@ struct TcpChannelIdentifier {
 }
 
 impl TcpChannelIdentifier {
+    #[allow(clippy::unused_io_amount)]
     fn new(src: SocketAddr, dst: SocketAddr) -> std::io::Result<Self> {
         let mut id = vec![];
 

--- a/aucpace/examples/key_agreement.rs
+++ b/aucpace/examples/key_agreement.rs
@@ -292,18 +292,18 @@ impl TcpChannelIdentifier {
 
         // write src.ip:src.port:dst.ip:dst.port
         match src.ip() {
-            IpAddr::V4(addr) => id.write(&addr.octets()),
-            IpAddr::V6(addr) => id.write(&addr.octets()),
+            IpAddr::V4(addr) => id.write_all(&addr.octets()),
+            IpAddr::V6(addr) => id.write_all(&addr.octets()),
         }?;
         id.push(b':');
-        id.write(&src.port().to_be_bytes())?;
+        id.write_all(&src.port().to_be_bytes())?;
         id.push(b':');
         match dst.ip() {
-            IpAddr::V4(addr) => id.write(&addr.octets()),
-            IpAddr::V6(addr) => id.write(&addr.octets()),
+            IpAddr::V4(addr) => id.write_all(&addr.octets()),
+            IpAddr::V6(addr) => id.write_all(&addr.octets()),
         }?;
         id.push(b':');
-        id.write(&dst.port().to_be_bytes())?;
+        id.write_all(&dst.port().to_be_bytes())?;
 
         Ok(Self { id })
     }

--- a/aucpace/examples/key_agreement.rs
+++ b/aucpace/examples/key_agreement.rs
@@ -286,7 +286,6 @@ struct TcpChannelIdentifier {
 }
 
 impl TcpChannelIdentifier {
-    #[allow(clippy::unused_io_amount)]
     fn new(src: SocketAddr, dst: SocketAddr) -> std::io::Result<Self> {
         let mut id = vec![];
 

--- a/aucpace/examples/key_agreement_no_std.rs
+++ b/aucpace/examples/key_agreement_no_std.rs
@@ -28,8 +28,8 @@ macro_rules! recv {
 
 fn main() -> Result<()> {
     // example username and password, never user these...
-    const USERNAME: &'static [u8] = b"adira.tal";
-    const PASSWORD: &'static [u8] = b"4d1rA_aND-Gr4Y_aRe_tH3-b3sT <3";
+    const USERNAME: &[u8] = b"adira.tal";
+    const PASSWORD: &[u8] = b"4d1rA_aND-Gr4Y_aRe_tH3-b3sT <3";
 
     // register the user in the database
     let mut base_server = Server::new(OsRng);
@@ -148,7 +148,7 @@ fn main() -> Result<()> {
 
     // ===== CPace substep =====
     // first generate the server's public key and send it
-    const CI: &'static str = "channel_identifier";
+    const CI: &str = "channel_identifier";
     let (server, message) = server.generate_public_key(CI);
     let bytes_sent = send!(server_buf, message);
     server_bytes_sent += bytes_sent;

--- a/aucpace/examples/key_agreement_partial_aug.rs
+++ b/aucpace/examples/key_agreement_partial_aug.rs
@@ -325,7 +325,6 @@ struct TcpChannelIdentifier {
 }
 
 impl TcpChannelIdentifier {
-    #[allow(clippy::unused_io_amount)]
     fn new(src: SocketAddr, dst: SocketAddr) -> std::io::Result<Self> {
         let mut id = vec![];
 

--- a/aucpace/examples/key_agreement_partial_aug.rs
+++ b/aucpace/examples/key_agreement_partial_aug.rs
@@ -331,18 +331,18 @@ impl TcpChannelIdentifier {
 
         // write src.ip:src.port:dst.ip:dst.port
         match src.ip() {
-            IpAddr::V4(addr) => id.write(&addr.octets()),
-            IpAddr::V6(addr) => id.write(&addr.octets()),
+            IpAddr::V4(addr) => id.write_all(&addr.octets()),
+            IpAddr::V6(addr) => id.write_all(&addr.octets()),
         }?;
         id.push(b':');
-        id.write(&src.port().to_be_bytes())?;
+        id.write_all(&src.port().to_be_bytes())?;
         id.push(b':');
         match dst.ip() {
-            IpAddr::V4(addr) => id.write(&addr.octets()),
-            IpAddr::V6(addr) => id.write(&addr.octets()),
+            IpAddr::V4(addr) => id.write_all(&addr.octets()),
+            IpAddr::V6(addr) => id.write_all(&addr.octets()),
         }?;
         id.push(b':');
-        id.write(&dst.port().to_be_bytes())?;
+        id.write_all(&dst.port().to_be_bytes())?;
 
         Ok(Self { id })
     }

--- a/aucpace/examples/key_agreement_partial_aug.rs
+++ b/aucpace/examples/key_agreement_partial_aug.rs
@@ -34,8 +34,8 @@ macro_rules! recv {
 
 fn main() -> Result<()> {
     // example username and password, never user these...
-    const USERNAME: &'static [u8] = b"jlpicard_1701";
-    const PASSWORD: &'static [u8] = b"g04tEd_c4pT41N";
+    const USERNAME: &[u8] = b"jlpicard_1701";
+    const PASSWORD: &[u8] = b"g04tEd_c4pT41N";
 
     // the server socket address to bind to
     let server_socket: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 25519);
@@ -297,7 +297,7 @@ impl PartialAugDatabase for SingleUserDatabase {
         username: &[u8],
     ) -> Option<(Self::PrivateKey, Self::PublicKey)> {
         match &self.user {
-            Some(stored_user) if stored_user == username => self.long_term_keypair.clone(),
+            Some(stored_user) if stored_user == username => self.long_term_keypair,
             _ => None,
         }
     }
@@ -325,6 +325,7 @@ struct TcpChannelIdentifier {
 }
 
 impl TcpChannelIdentifier {
+    #[allow(clippy::unused_io_amount)]
     fn new(src: SocketAddr, dst: SocketAddr) -> std::io::Result<Self> {
         let mut id = vec![];
 

--- a/aucpace/examples/key_agreement_strong.rs
+++ b/aucpace/examples/key_agreement_strong.rs
@@ -297,18 +297,18 @@ impl TcpChannelIdentifier {
 
         // write src.ip:src.port:dst.ip:dst.port
         match src.ip() {
-            IpAddr::V4(addr) => id.write(&addr.octets()),
-            IpAddr::V6(addr) => id.write(&addr.octets()),
+            IpAddr::V4(addr) => id.write_all(&addr.octets()),
+            IpAddr::V6(addr) => id.write_all(&addr.octets()),
         }?;
         id.push(b':');
-        id.write(&src.port().to_be_bytes())?;
+        id.write_all(&src.port().to_be_bytes())?;
         id.push(b':');
         match dst.ip() {
-            IpAddr::V4(addr) => id.write(&addr.octets()),
-            IpAddr::V6(addr) => id.write(&addr.octets()),
+            IpAddr::V4(addr) => id.write_all(&addr.octets()),
+            IpAddr::V6(addr) => id.write_all(&addr.octets()),
         }?;
         id.push(b':');
-        id.write(&dst.port().to_be_bytes())?;
+        id.write_all(&dst.port().to_be_bytes())?;
 
         Ok(Self { id })
     }

--- a/aucpace/examples/key_agreement_strong.rs
+++ b/aucpace/examples/key_agreement_strong.rs
@@ -32,8 +32,8 @@ macro_rules! recv {
 
 fn main() -> Result<()> {
     // example username and password, never user these...
-    const USERNAME: &'static [u8] = b"jlpicard_1701";
-    const PASSWORD: &'static [u8] = b"g04tEd_c4pT41N";
+    const USERNAME: &[u8] = b"jlpicard_1701";
+    const PASSWORD: &[u8] = b"g04tEd_c4pT41N";
 
     // the server socket address to bind to
     let server_socket: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 25519);
@@ -291,6 +291,7 @@ struct TcpChannelIdentifier {
 }
 
 impl TcpChannelIdentifier {
+    #[allow(clippy::unused_io_amount)]
     fn new(src: SocketAddr, dst: SocketAddr) -> std::io::Result<Self> {
         let mut id = vec![];
 

--- a/aucpace/examples/key_agreement_strong.rs
+++ b/aucpace/examples/key_agreement_strong.rs
@@ -291,7 +291,6 @@ struct TcpChannelIdentifier {
 }
 
 impl TcpChannelIdentifier {
-    #[allow(clippy::unused_io_amount)]
     fn new(src: SocketAddr, dst: SocketAddr) -> std::io::Result<Self> {
         let mut id = vec![];
 

--- a/aucpace/src/client.rs
+++ b/aucpace/src/client.rs
@@ -32,7 +32,7 @@ use crate::utils::{serde_paramsstring, serde_saltstring};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// Implementation of the client side of the AuCPace protocol
+/// Implementation of the client side of the `AuCPace` protocol
 pub struct AuCPaceClient<D, H, CSPRNG, const K1: usize>
 where
     D: Digest<OutputSize = U64> + Default,
@@ -51,11 +51,11 @@ where
     CSPRNG: CryptoRngCore,
 {
     /// Create new server
-    pub fn new(rng: CSPRNG) -> Self {
+    pub const fn new(rng: CSPRNG) -> Self {
         Self {
             rng,
-            d: Default::default(),
-            h: Default::default(),
+            d: PhantomData,
+            h: PhantomData,
         }
     }
 
@@ -362,8 +362,8 @@ where
     {
         Self {
             nonce: generate_nonce(rng),
-            d: Default::default(),
-            h: Default::default(),
+            d: PhantomData,
+            h: PhantomData,
         }
     }
 
@@ -375,6 +375,7 @@ where
     /// # return:
     /// [`next_step`](AuCPaceClientPreAug): the client in the pre-augmentation stage
     ///
+    #[must_use]
     pub fn agree_ssid(self, server_nonce: [u8; K1]) -> AuCPaceClientPreAug<D, H, K1> {
         let ssid = compute_ssid::<D, K1>(server_nonce, self.nonce);
         AuCPaceClientPreAug::new(ssid)
@@ -396,10 +397,10 @@ where
     D: Digest<OutputSize = U64> + Default,
     H: PasswordHasher,
 {
-    fn new(ssid: Output<D>) -> Self {
+    const fn new(ssid: Output<D>) -> Self {
         Self {
             ssid,
-            h: Default::default(),
+            h: PhantomData,
         }
     }
 
@@ -413,7 +414,8 @@ where
     /// - [`next_step`](AuCPaceClientAugLayer): the client in the augmentation layer
     /// - [`message`](ClientMessage::Username): the message to send to the server
     ///
-    pub fn start_augmentation<'a>(
+    #[must_use]
+    pub const fn start_augmentation<'a>(
         self,
         username: &'a [u8],
         password: &'a [u8],
@@ -488,12 +490,12 @@ where
     D: Digest<OutputSize = U64> + Default,
     H: PasswordHasher,
 {
-    fn new(ssid: Output<D>, username: &'a [u8], password: &'a [u8]) -> Self {
+    const fn new(ssid: Output<D>, username: &'a [u8], password: &'a [u8]) -> Self {
         Self {
             ssid,
             username,
             password,
-            h: Default::default(),
+            h: PhantomData,
         }
     }
 
@@ -612,7 +614,7 @@ where
     D: Digest<OutputSize = U64> + Default,
     H: PasswordHasher,
 {
-    fn new(
+    const fn new(
         ssid: Output<D>,
         username: &'a [u8],
         password: &'a [u8],
@@ -623,7 +625,7 @@ where
             username,
             password,
             blinding_value,
-            h: Default::default(),
+            h: PhantomData,
         }
     }
 
@@ -747,7 +749,7 @@ where
     }
 }
 
-/// Client in the CPace substep
+/// Client in the `CPace` substep
 pub struct AuCPaceClientCPaceSubstep<D, const K1: usize>
 where
     D: Digest<OutputSize = U64> + Default,
@@ -760,12 +762,12 @@ impl<D, const K1: usize> AuCPaceClientCPaceSubstep<D, K1>
 where
     D: Digest<OutputSize = U64> + Default,
 {
-    fn new(ssid: Output<D>, prs: [u8; 32]) -> Self {
+    const fn new(ssid: Output<D>, prs: [u8; 32]) -> Self {
         Self { ssid, prs }
     }
 
     /// Generate a public key
-    /// moving the protocol onto the second half of the CPace substep - Receive Server Pubkey
+    /// moving the protocol onto the second half of the `CPace` substep - Receive Server Pubkey
     ///
     /// # Arguments:
     /// - `channel_identifier` - `CI` from the protocol definition, in the context of TCP/IP this
@@ -813,12 +815,12 @@ impl<D, const K1: usize> AuCPaceClientRecvServerKey<D, K1>
 where
     D: Digest<OutputSize = U64> + Default,
 {
-    fn new(ssid: Output<D>, priv_key: Scalar) -> Self {
+    const fn new(ssid: Output<D>, priv_key: Scalar) -> Self {
         Self { ssid, priv_key }
     }
 
     /// Receive the server's public key
-    /// This completes the CPace substep and moves the client on to explicit mutual authentication.
+    /// This completes the `CPace` substep and moves the client on to explicit mutual authentication.
     ///
     /// # Arguments:
     /// - `server_pubkey` - the server's public key
@@ -855,7 +857,7 @@ where
     /// - `server_pubkey` - the server's public key
     ///
     /// # Return:
-    /// `sk`: the session key reached by the AuCPace protocol
+    /// `sk`: the session key reached by the `AuCPace` protocol
     ///
     pub fn implicit_auth(self, server_pubkey: RistrettoPoint) -> Result<Output<D>> {
         if server_pubkey.is_identity() {
@@ -881,7 +883,7 @@ impl<D, const K1: usize> AuCPaceClientExpMutAuth<D, K1>
 where
     D: Digest<OutputSize = U64> + Default,
 {
-    fn new(ssid: Output<D>, sk1: Output<D>, server_authenticator: Output<D>) -> Self {
+    const fn new(ssid: Output<D>, sk1: Output<D>, server_authenticator: Output<D>) -> Self {
         Self {
             ssid,
             sk1,
@@ -897,7 +899,7 @@ where
     ///
     /// # Return:
     /// either:
-    /// - Ok(`sk`): the session key reached by the AuCPace protocol
+    /// - Ok(`sk`): the session key reached by the `AuCPace` protocol
     /// - Err([`Error::MutualAuthFail`](Error::MutualAuthFail)): an error if the authenticator we computed doesn't match
     ///     the server's authenticator, compared in constant time.
     ///
@@ -915,6 +917,7 @@ where
 }
 
 /// Hash a username and password with the given password hasher
+// TODO: change this to `hasher: &H` on the next breaking release
 fn hash_password<'a, U, P, S, H, const BUFSIZ: usize>(
     username: U,
     password: P,
@@ -940,16 +943,17 @@ where
     let mut buf = [0u8; BUFSIZ];
     buf[0..u].copy_from_slice(user);
     buf[u] = b':';
-    buf[u + 1..u + p + 1].copy_from_slice(pass);
+    buf[(u + 1)..=(u + p)].copy_from_slice(pass);
 
     let hash = hasher
-        .hash_password_customized(&buf[0..u + p + 1], None, None, params, salt)
+        .hash_password_customized(&buf[0..=(u + p)], None, None, params, salt)
         .map_err(Error::PasswordHashing);
 
     hash
 }
 
 /// Hash a username and password with the given password hasher
+// TODO: change this to `hasher: &H` on the next breaking release
 #[cfg(feature = "alloc")]
 fn hash_password_alloc<'a, U, P, S, H>(
     username: U,
@@ -988,7 +992,7 @@ pub enum ClientMessage<'a, const K1: usize> {
     /// Username - the client's username
     Username(&'a [u8]),
 
-    /// StrongUsername - the strong AuCPace username message
+    /// StrongUsername - the strong `AuCPace` username message
     /// also contains the blinded point `U`
     #[cfg(feature = "strong_aucpace")]
     StrongUsername {

--- a/aucpace/src/client.rs
+++ b/aucpace/src/client.rs
@@ -135,11 +135,11 @@ where
             password,
             &salt_string,
             params.clone(),
-            hasher,
+            &hasher,
         )?;
 
         let cofactor = Scalar::ONE;
-        let w = scalar_from_hash(pw_hash)?;
+        let w = scalar_from_hash(&pw_hash)?;
         let verifier = RISTRETTO_BASEPOINT_POINT * (w * cofactor);
 
         // attempt to convert the parameters to a ParamsString
@@ -192,10 +192,10 @@ where
             password,
             &salt_string,
             params.clone(),
-            hasher,
+            &hasher,
         )?;
         let cofactor = Scalar::ONE;
-        let w = scalar_from_hash(pw_hash)?;
+        let w = scalar_from_hash(&pw_hash)?;
         let verifier = RISTRETTO_BASEPOINT_POINT * (w * cofactor);
 
         // attempt to convert the parameters to a ParamsString
@@ -240,9 +240,9 @@ where
 
         // compute the verifier W
         let pw_hash =
-            hash_password_alloc(username, password, &salt_string, params.clone(), hasher)?;
+            hash_password_alloc(username, password, &salt_string, params.clone(), &hasher)?;
         let cofactor = Scalar::ONE;
-        let w = scalar_from_hash(pw_hash)?;
+        let w = scalar_from_hash(&pw_hash)?;
         let verifier = RISTRETTO_BASEPOINT_POINT * (w * cofactor);
 
         // attempt to convert the parameters to a ParamsString
@@ -297,10 +297,10 @@ where
             password,
             salt_string.as_salt(),
             params.clone(),
-            hasher,
+            &hasher,
         )?;
         let cofactor = Scalar::ONE;
-        let w = scalar_from_hash(pw_hash)?;
+        let w = scalar_from_hash(&pw_hash)?;
         let verifier = RISTRETTO_BASEPOINT_POINT * (w * cofactor);
 
         // attempt to convert the parameters to a ParamsString
@@ -542,9 +542,9 @@ where
             self.password,
             salt,
             params,
-            hasher,
+            &hasher,
         )?;
-        let w = scalar_from_hash(pw_hash)?;
+        let w = scalar_from_hash(&pw_hash)?;
 
         let prs = (x_pub * (w * cofactor)).compress().to_bytes();
 
@@ -585,8 +585,8 @@ where
         }
 
         let cofactor = Scalar::ONE;
-        let pw_hash = hash_password_alloc(self.username, self.password, salt, params, hasher)?;
-        let w = scalar_from_hash(pw_hash)?;
+        let pw_hash = hash_password_alloc(self.username, self.password, salt, params, &hasher)?;
+        let w = scalar_from_hash(&pw_hash)?;
 
         let prs = (x_pub * (w * cofactor)).compress().to_bytes();
 
@@ -679,9 +679,9 @@ where
             self.password,
             &salt_string,
             params,
-            hasher,
+            &hasher,
         )?;
-        let w = scalar_from_hash(pw_hash)?;
+        let w = scalar_from_hash(&pw_hash)?;
         let prs = (x_pub * (w * cofactor)).compress().to_bytes();
 
         Ok(AuCPaceClientCPaceSubstep::new(self.ssid, prs))
@@ -740,9 +740,9 @@ where
             self.password,
             salt_string.as_salt(),
             params,
-            hasher,
+            &hasher,
         )?;
-        let w = scalar_from_hash(pw_hash)?;
+        let w = scalar_from_hash(&pw_hash)?;
         let prs = (x_pub * (w * cofactor)).compress().to_bytes();
 
         Ok(AuCPaceClientCPaceSubstep::new(self.ssid, prs))
@@ -917,13 +917,12 @@ where
 }
 
 /// Hash a username and password with the given password hasher
-// TODO: change this to `hasher: &H` on the next breaking release
 fn hash_password<'a, U, P, S, H, const BUFSIZ: usize>(
     username: U,
     password: P,
     salt: S,
     params: H::Params,
-    hasher: H,
+    hasher: &H,
 ) -> Result<PasswordHash<'a>>
 where
     H: PasswordHasher,
@@ -953,14 +952,13 @@ where
 }
 
 /// Hash a username and password with the given password hasher
-// TODO: change this to `hasher: &H` on the next breaking release
 #[cfg(feature = "alloc")]
 fn hash_password_alloc<'a, U, P, S, H>(
     username: U,
     password: P,
     salt: S,
     params: H::Params,
-    hasher: H,
+    hasher: &H,
 ) -> Result<PasswordHash<'a>>
 where
     H: PasswordHasher,
@@ -1066,10 +1064,10 @@ mod tests {
         let params: Params = Default::default();
 
         let no_std_res = hash_password::<&str, &str, &SaltString, Scrypt, 100>(
-            username, password, &salt, params, Scrypt,
+            username, password, &salt, params, &Scrypt,
         )
         .unwrap();
-        let alloc_res = hash_password_alloc(username, password, &salt, params, Scrypt).unwrap();
+        let alloc_res = hash_password_alloc(username, password, &salt, params, &Scrypt).unwrap();
 
         assert_eq!(alloc_res, no_std_res);
     }

--- a/aucpace/src/database.rs
+++ b/aucpace/src/database.rs
@@ -2,7 +2,7 @@
 use crate::Result;
 use password_hash::{ParamsString, SaltString};
 
-/// trait for AuCPace to use to abstract over the storage and retrieval of verifiers
+/// trait for `AuCPace` to use to abstract over the storage and retrieval of verifiers
 pub trait Database {
     /// The type of password verifier stored in the database
     type PasswordVerifier;
@@ -46,7 +46,7 @@ pub trait Database {
     );
 }
 
-/// trait for AuCPace to use to abstract over the storage and retrieval of long-term keypairs
+/// trait for `AuCPace` to use to abstract over the storage and retrieval of long-term keypairs
 #[cfg(feature = "partial_augmentation")]
 pub trait PartialAugDatabase {
     /// The private key type
@@ -62,8 +62,8 @@ pub trait PartialAugDatabase {
     ///
     /// # Return:
     /// - Some((`public_key`, `private_key`)): if the user has a long term keypair associated with them
-    ///   - `private_key`: corresponds to x from the protocol definition
-    ///   - `public_key`: corresponds to x_pub from the protocol definition
+    ///   - `private_key`: corresponds to `x` from the protocol definition
+    ///   - `public_key`: corresponds to `x_pub` from the protocol definition
     /// - None: if the user has no associated keypair
     ///
     fn lookup_long_term_keypair(
@@ -93,7 +93,7 @@ pub trait PartialAugDatabase {
     ) -> Result<()>;
 }
 
-/// trait for AuCPace to use to abstract over the storage and retrieval of verifiers and secret exponents
+/// trait for `AuCPace` to use to abstract over the storage and retrieval of verifiers and secret exponents
 #[cfg(feature = "strong_aucpace")]
 pub trait StrongDatabase {
     /// The type of password verifier stored in the database

--- a/aucpace/src/errors.rs
+++ b/aucpace/src/errors.rs
@@ -29,21 +29,21 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::IllegalPointError => write!(f, "illegal point encountered"),
-            Error::PasswordHashing(error) => write!(f, "error while hashing password: {}", error),
-            Error::HashEmpty => write!(f, "password hash empty"),
-            Error::HashSizeInvalid => write!(f, "password hash invalid, should be 32 or 64 bytes"),
-            Error::MutualAuthFail => write!(
+            Self::IllegalPointError => write!(f, "illegal point encountered"),
+            Self::PasswordHashing(error) => write!(f, "error while hashing password: {error}"),
+            Self::HashEmpty => write!(f, "password hash empty"),
+            Self::HashSizeInvalid => write!(f, "password hash invalid, should be 32 or 64 bytes"),
+            Self::MutualAuthFail => write!(
                 f,
                 "explicit mutual authentication failed, authenticators didn't match"
             ),
-            Error::UsernameOrPasswordTooLong => write!(f, "username or password too long"),
-            Error::InsecureSsid => write!(
+            Self::UsernameOrPasswordTooLong => write!(f, "username or password too long"),
+            Self::InsecureSsid => write!(
                 f,
                 "provided SSID is insecure - SSIDs must be at least 16 bytes long"
             ),
             #[cfg(feature = "partial_augmentation")]
-            Error::UserNotRegistered => write!(
+            Self::UserNotRegistered => write!(
                 f,
                 "user must be registered before a long-term keypair can be stored"
             ),

--- a/aucpace/src/lib.rs
+++ b/aucpace/src/lib.rs
@@ -21,10 +21,10 @@
 //! [`server`](server/index.html) modules.
 //!
 //! # Protocol description
-//! Here we briefly describe the AuCPace Protocol. For additional information
-//! refer to AuCPace literature[1]. All arithmetic is done on the (hyper-) elliptic curve `C`
+//! Here we briefly describe the `AuCPace` Protocol. For additional information
+//! refer to `AuCPace` literature[1]. All arithmetic is done on the (hyper-) elliptic curve `C`
 //! in group `J`, with co-factor `c_J` and Diffie-Hellman base point `B` in `J`.
-//! It's STRONGLY recommended to use AuCPace parameters provided by this crate
+//! It's STRONGLY recommended to use `AuCPace` parameters provided by this crate
 //! in the [`Client`](Client) and [`Server`](Server) default instantiations.
 //!
 //! |       Server                    |   Data transfer   |      Client                     |
@@ -86,10 +86,10 @@ mod database;
 mod errors;
 mod utils;
 
-/// Module containing the implementation of the client for the AuCPace protocol
+/// Module containing the implementation of the client for the `AuCPace` protocol
 pub mod client;
 
-/// Module containing the implementation of the server for the AuCPace protocol
+/// Module containing the implementation of the server for the `AuCPace` protocol
 pub mod server;
 
 /// Module contains constants used in the code
@@ -108,10 +108,10 @@ pub use self::database::PartialAugDatabase;
 #[cfg(feature = "strong_aucpace")]
 pub use self::database::StrongDatabase;
 
-/// Default Server instantiation with SHA512, OsRng and a nonce size of 16 bytes
+/// Default Server instantiation with `SHA512`, `OsRng` and a nonce size of 16 bytes
 #[cfg(all(feature = "sha2", feature = "getrandom"))]
 pub type Server = AuCPaceServer<sha2::Sha512, rand_core::OsRng, 16>;
 
-/// Default Client instantiation with SHA512, Scrypt, OsRng and a nonce size of 16 bytes
+/// Default Client instantiation with `SHA512`, `Scrypt`, `OsRng` and a nonce size of 16 bytes
 #[cfg(all(feature = "scrypt", feature = "sha2", feature = "getrandom"))]
 pub type Client = AuCPaceClient<sha2::Sha512, scrypt::Scrypt, rand_core::OsRng, 16>;

--- a/aucpace/src/server.rs
+++ b/aucpace/src/server.rs
@@ -745,7 +745,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "sha2"))]
+    #[cfg(feature = "sha2")]
     fn test_server_doesnt_accept_invalid_pubkey() {
         use crate::utils::H0;
         use curve25519_dalek::traits::Identity;
@@ -762,7 +762,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "sha2"))]
+    #[cfg(feature = "sha2")]
     fn test_server_doesnt_accept_invalid_pubkey_implicit_auth() {
         use crate::utils::H0;
         use curve25519_dalek::traits::Identity;

--- a/aucpace/src/server.rs
+++ b/aucpace/src/server.rs
@@ -39,7 +39,7 @@ impl ServerSecret {
     }
 }
 
-/// Implementation of the server side of the AuCPace protocol
+/// Implementation of the server side of the `AuCPace` protocol
 pub struct AuCPaceServer<D, CSPRNG, const K1: usize>
 where
     D: Digest + Default,
@@ -65,7 +65,7 @@ where
         Self {
             rng,
             secret,
-            d: Default::default(),
+            d: PhantomData,
         }
     }
 
@@ -150,7 +150,7 @@ where
         Self {
             secret,
             nonce: generate_nonce(rng),
-            _d: Default::default(),
+            _d: PhantomData,
         }
     }
 
@@ -162,6 +162,7 @@ where
     /// # return:
     /// [`next_step`](AuCPaceServerAugLayer): the server in the augmentation layer
     ///
+    #[must_use]
     pub fn agree_ssid(self, client_nonce: [u8; K1]) -> AuCPaceServerAugLayer<D, K1> {
         let ssid = compute_ssid::<D, K1>(self.nonce, client_nonce);
         AuCPaceServerAugLayer::new(self.secret, ssid)
@@ -181,12 +182,12 @@ impl<D, const K1: usize> AuCPaceServerAugLayer<D, K1>
 where
     D: Digest<OutputSize = U64> + Default,
 {
-    fn new(secret: ServerSecret, ssid: Output<D>) -> Self {
+    const fn new(secret: ServerSecret, ssid: Output<D>) -> Self {
         Self { secret, ssid }
     }
 
-    /// Accept the user's username and generate the ClientInfo for the response.
-    /// Moves the protocol into the CPace substep phase
+    /// Accept the user's username and generate the `ClientInfo` for the response.
+    /// Moves the protocol into the `CPace` substep phase
     ///
     /// # Arguments:
     /// - `username`: the client's username
@@ -194,7 +195,7 @@ where
     ///
     /// # Return:
     /// ([`next_step`](AuCPaceServerCPaceSubstep), [`message`](ServerMessage::AugmentationInfo))
-    /// - [`next_step`](AuCPaceServerCPaceSubstep): the server in the CPace substep stage
+    /// - [`next_step`](AuCPaceServerCPaceSubstep): the server in the `CPace` substep stage
     /// - [`message`](ServerMessage::AugmentationInfo): the message to send to the client
     ///
     pub fn generate_client_info<U, DB, CSPRNG>(
@@ -220,11 +221,11 @@ where
         (next_step, message)
     }
 
-    /// Accept the user's username and generate the ClientInfo for the response.
-    /// Moves the protocol into the CPace substep phase
+    /// Accept the user's username and generate the `ClientInfo` for the response.
+    /// Moves the protocol into the `CPace` substep phase
     ///
     /// This method performs the "partial augmentation" variant of the protocol.
-    /// This means that instead of generating x and x_pub as ephemeral keys, a long term keypair is
+    /// This means that instead of generating `x` and `x_pub` as ephemeral keys, a long term keypair is
     /// retrieved from the database instead. This comes with decreased security in the case of
     /// server compromise but significantly decreases the amount of computation the server has to
     /// do. The reference paper goes into more detail on the tradeoffs and why you might choose to
@@ -233,11 +234,11 @@ where
     /// # Arguments:
     /// - `username`: the client's username
     /// - `database`: the password verifier database to retrieve the client's information from
-    ///    This is a PartialAugDatabase so we can lookup the server's long term keypair.
+    ///    This is a `PartialAugDatabase` so we can lookup the server's long term keypair.
     ///
     /// # Return:
     /// ([`next_step`](AuCPaceServerCPaceSubstep), [`message`](ServerMessage::AugmentationInfo))
-    /// - [`next_step`](AuCPaceServerCPaceSubstep): the server in the CPace substep stage
+    /// - [`next_step`](AuCPaceServerCPaceSubstep): the server in the `CPace` substep stage
     /// - [`message`](ServerMessage::AugmentationInfo): the message to send to the client
     ///
     #[cfg(feature = "partial_augmentation")]
@@ -271,8 +272,8 @@ where
         (next_step, message)
     }
 
-    /// Accept the user's username, and blinded point U and generate the ClientInfo for the response.
-    /// Moves the protocol into the CPace substep phase
+    /// Accept the user's username, and blinded point U and generate the `ClientInfo` for the response.
+    /// Moves the protocol into the `CPace` substep phase
     ///
     /// This method performs the Strong variant of the protocol.
     /// This means that the information is blinded in transit so that it is impossible to do any
@@ -282,11 +283,11 @@ where
     /// - `username`: the client's username
     /// - `blinded`: the client's blinded point `U`
     /// - `database`: the password verifier database to retrieve the client's information from
-    ///    This is a PartialAugDatabase so we can lookup the server's long term keypair.
+    ///    This is a `PartialAugDatabase` so we can lookup the server's long term keypair.
     ///
     /// # Return:
     /// ([`next_step`](AuCPaceServerCPaceSubstep), [`message`](ServerMessage::AugmentationInfo))
-    /// - [`next_step`](AuCPaceServerCPaceSubstep): the server in the CPace substep stage
+    /// - [`next_step`](AuCPaceServerCPaceSubstep): the server in the `CPace` substep stage
     /// - [`message`](ServerMessage::AugmentationInfo): the message to send to the client
     ///
     #[cfg(feature = "strong_aucpace")]
@@ -315,8 +316,8 @@ where
         Ok((next_step, message))
     }
 
-    /// Accept the user's username, and blinded point U and generate the ClientInfo for the response.
-    /// Moves the protocol into the CPace substep phase
+    /// Accept the user's username, and blinded point U and generate the `ClientInfo` for the response.
+    /// Moves the protocol into the `CPace` substep phase
     ///
     /// This method performs the Strong + Partially augmented variant of the protocol.
     /// This means that the information is blinded in transit so that it is impossible to do any
@@ -327,11 +328,11 @@ where
     /// - `username`: the client's username
     /// - `blinded`: the client's blinded point `U`
     /// - `database`: the password verifier database to retrieve the client's information from
-    ///    This is a PartialAugDatabase so we can lookup the server's long term keypair.
+    ///    This is a `PartialAugDatabase` so we can lookup the server's long term keypair.
     ///
     /// # Return:
     /// ([`next_step`](AuCPaceServerCPaceSubstep), [`message`](ServerMessage::AugmentationInfo))
-    /// - [`next_step`](AuCPaceServerCPaceSubstep): the server in the CPace substep stage
+    /// - [`next_step`](AuCPaceServerCPaceSubstep): the server in the `CPace` substep stage
     /// - [`message`](ServerMessage::AugmentationInfo): the message to send to the client
     ///
     #[cfg(all(feature = "strong_aucpace", feature = "partial_augmentation"))]
@@ -466,7 +467,7 @@ where
             group: "ristretto255",
             x_pub,
             salt,
-            pbkdf_params: Default::default(),
+            pbkdf_params: ParamsString::default(),
         };
 
         (prs, message)
@@ -507,14 +508,14 @@ where
             group: "ristretto255",
             x_pub,
             blinded_salt: fake_blinded_salt,
-            pbkdf_params: Default::default(),
+            pbkdf_params: ParamsString::default(),
         };
 
         Ok((prs, message))
     }
 }
 
-/// Server in the CPace substep phase
+/// Server in the `CPace` substep phase
 pub struct AuCPaceServerCPaceSubstep<D, CSPRNG, const K1: usize>
 where
     D: Digest<OutputSize = U64> + Default,
@@ -530,12 +531,12 @@ where
     D: Digest<OutputSize = U64> + Default,
     CSPRNG: CryptoRngCore,
 {
-    fn new(ssid: Output<D>, prs: [u8; 32], rng: CSPRNG) -> Self {
+    const fn new(ssid: Output<D>, prs: [u8; 32], rng: CSPRNG) -> Self {
         Self { ssid, prs, rng }
     }
 
     /// Generate a public key
-    /// moving the protocol onto the second half of the CPace substep - Receive Server Pubkey
+    /// moving the protocol onto the second half of the `CPace` substep - Receive Server Pubkey
     ///
     /// # Arguments:
     /// - `channel_identifier` - `CI` from the protocol definition, in the context of TCP/IP this
@@ -569,7 +570,7 @@ where
     }
 }
 
-/// Server in the CPace substep phase
+/// Server in the `CPace` substep phase
 pub struct AuCPaceServerRecvClientKey<D, const K1: usize>
 where
     D: Digest<OutputSize = U64> + Default,
@@ -582,12 +583,12 @@ impl<D, const K1: usize> AuCPaceServerRecvClientKey<D, K1>
 where
     D: Digest<OutputSize = U64> + Default,
 {
-    fn new(ssid: Output<D>, priv_key: Scalar) -> Self {
+    const fn new(ssid: Output<D>, priv_key: Scalar) -> Self {
         Self { ssid, priv_key }
     }
 
     /// Receive the client's public key
-    /// This completes the CPace substep and moves the client on to explicit mutual authentication.
+    /// This completes the `CPace` substep and moves the client on to explicit mutual authentication.
     ///
     /// # Arguments:
     /// - `client_pubkey` - the client's public key
@@ -616,7 +617,7 @@ where
     /// - `client_pubkey` - the client's public key
     ///
     /// # Return:
-    /// `sk`: the session key reached by the AuCPace protocol
+    /// `sk`: the session key reached by the `AuCPace` protocol
     ///
     pub fn implicit_auth(self, client_pubkey: RistrettoPoint) -> Result<Output<D>> {
         // check for the neutral point
@@ -642,7 +643,7 @@ impl<D, const K1: usize> AuCPaceServerExpMutAuth<D, K1>
 where
     D: Digest<OutputSize = U64> + Default,
 {
-    fn new(ssid: Output<D>, sk1: Output<D>) -> Self {
+    const fn new(ssid: Output<D>, sk1: Output<D>) -> Self {
         Self { ssid, sk1 }
     }
 
@@ -655,7 +656,7 @@ where
     /// # Return:
     /// either:
     /// - Ok((`sk`, `message`)):
-    ///     - `sk` - the session key reached by the AuCPace protocol
+    ///     - `sk` - the session key reached by the `AuCPace` protocol
     ///     - [`message`](ServerMessage::Authenticator) - the message to send to the client
     /// - Err([`Error::MutualAuthFail`](Error::MutualAuthFail)): an error if the authenticator we computed doesn't match
     ///     the client's authenticator, compared in constant time.
@@ -720,7 +721,7 @@ pub enum ServerMessage<'a, const K1: usize> {
         pbkdf_params: ParamsString,
     },
 
-    /// CPace substep message - the server's public key: `Ya`
+    /// `CPace` substep message - the server's public key: `Ya`
     PublicKey(RistrettoPoint),
 
     /// Explicit Mutual Authentication - the server's authenticator: `Ta`

--- a/aucpace/src/utils.rs
+++ b/aucpace/src/utils.rs
@@ -130,9 +130,7 @@ where
 
 /// Compute a scalar from a password hash
 #[inline]
-#[allow(clippy::needless_pass_by_value)]
-// TODO: change this to `&PasswordHash<'_>` on the next breaking release
-pub fn scalar_from_hash(pw_hash: PasswordHash<'_>) -> Result<Scalar> {
+pub fn scalar_from_hash(pw_hash: &PasswordHash<'_>) -> Result<Scalar> {
     let hash = pw_hash.hash.ok_or(Error::HashEmpty)?;
     let hash_bytes = hash.as_bytes();
 

--- a/aucpace/src/utils.rs
+++ b/aucpace/src/utils.rs
@@ -10,7 +10,7 @@ use password_hash::PasswordHash;
 use rand_core::CryptoRngCore;
 
 #[allow(non_snake_case)]
-#[inline(always)]
+#[inline]
 fn H<D: Digest + Default, const N: u32>() -> D {
     let mut hasher: D = Default::default();
     hasher.update(N.to_le_bytes());
@@ -20,7 +20,7 @@ fn H<D: Digest + Default, const N: u32>() -> D {
 macro_rules! create_h_impl {
     ($name:ident, $n:literal) => {
         #[allow(non_snake_case)]
-        pub(crate) fn $name<D: Digest + Default>() -> D {
+        pub fn $name<D: Digest + Default>() -> D {
             H::<D, $n>()
         }
     };
@@ -35,8 +35,8 @@ create_h_impl!(H4, 4);
 create_h_impl!(H5, 5);
 
 /// Generate a fixed length nonce using a CSPRNG
-#[inline(always)]
-pub(crate) fn generate_nonce<CSPRNG, const N: usize>(rng: &mut CSPRNG) -> [u8; N]
+#[inline]
+pub fn generate_nonce<CSPRNG, const N: usize>(rng: &mut CSPRNG) -> [u8; N]
 where
     CSPRNG: CryptoRngCore,
 {
@@ -46,20 +46,17 @@ where
 }
 
 /// Computes the SSID from two server and client nonces - s and t
-#[inline(always)]
-pub(crate) fn compute_ssid<D: Digest + Default, const K1: usize>(
-    s: [u8; K1],
-    t: [u8; K1],
-) -> Output<D> {
+#[inline]
+pub fn compute_ssid<D: Digest + Default, const K1: usize>(s: [u8; K1], t: [u8; K1]) -> Output<D> {
     let mut hasher: D = H0();
     hasher.update(s);
     hasher.update(t);
     hasher.finalize()
 }
 
-/// Generate a Diffie-Hellman keypair for the CPace substep of the protocol
-#[inline(always)]
-pub(crate) fn generate_keypair<D, CSPRNG, CI>(
+/// Generate a Diffie-Hellman keypair for the `CPace` substep of the protocol
+#[inline]
+pub fn generate_keypair<D, CSPRNG, CI>(
     rng: &mut CSPRNG,
     ssid: Output<D>,
     prs: [u8; 32],
@@ -84,8 +81,8 @@ where
 }
 
 /// Compute the first session key sk1 from our private key and the other participant's public key
-#[inline(always)]
-pub(crate) fn compute_first_session_key<D>(
+#[inline]
+pub fn compute_first_session_key<D>(
     ssid: Output<D>,
     priv_key: Scalar,
     pub_key: RistrettoPoint,
@@ -103,11 +100,8 @@ where
 }
 
 /// Compute the two authenticator messages Ta and Tb
-#[inline(always)]
-pub(crate) fn compute_authenticator_messages<D>(
-    ssid: Output<D>,
-    sk1: Output<D>,
-) -> (Output<D>, Output<D>)
+#[inline]
+pub fn compute_authenticator_messages<D>(ssid: Output<D>, sk1: Output<D>) -> (Output<D>, Output<D>)
 where
     D: Digest<OutputSize = U64> + Default,
 {
@@ -123,8 +117,8 @@ where
 }
 
 /// Compute the session key - sk
-#[inline(always)]
-pub(crate) fn compute_session_key<D>(ssid: Output<D>, sk1: Output<D>) -> Output<D>
+#[inline]
+pub fn compute_session_key<D>(ssid: Output<D>, sk1: Output<D>) -> Output<D>
 where
     D: Digest<OutputSize = U64> + Default,
 {
@@ -135,8 +129,10 @@ where
 }
 
 /// Compute a scalar from a password hash
-#[inline(always)]
-pub(crate) fn scalar_from_hash(pw_hash: PasswordHash<'_>) -> Result<Scalar> {
+#[inline]
+#[allow(clippy::needless_pass_by_value)]
+// TODO: change this to `&PasswordHash<'_>` on the next breaking release
+pub fn scalar_from_hash(pw_hash: PasswordHash<'_>) -> Result<Scalar> {
     let hash = pw_hash.hash.ok_or(Error::HashEmpty)?;
     let hash_bytes = hash.as_bytes();
 
@@ -159,8 +155,8 @@ pub(crate) fn scalar_from_hash(pw_hash: PasswordHash<'_>) -> Result<Scalar> {
 }
 
 /// Generate a keypair (x, X) for the server
-#[inline(always)]
-pub(crate) fn generate_server_keypair<CSPRNG>(rng: &mut CSPRNG) -> (Scalar, RistrettoPoint)
+#[inline]
+pub fn generate_server_keypair<CSPRNG>(rng: &mut CSPRNG) -> (Scalar, RistrettoPoint)
 where
     CSPRNG: CryptoRngCore,
 {
@@ -175,7 +171,7 @@ where
 
 // serde_with helper modules for serialising
 #[cfg(feature = "serde")]
-pub(crate) mod serde_saltstring {
+pub mod serde_saltstring {
     use core::fmt;
     use password_hash::SaltString;
     use serde::de::{Error, Visitor};
@@ -214,7 +210,7 @@ pub(crate) mod serde_saltstring {
 }
 
 #[cfg(feature = "serde")]
-pub(crate) mod serde_paramsstring {
+pub mod serde_paramsstring {
     use core::fmt;
     use password_hash::ParamsString;
     use serde::de::{Error, Visitor};

--- a/aucpace/src/utils.rs
+++ b/aucpace/src/utils.rs
@@ -213,7 +213,7 @@ pub(crate) mod serde_saltstring {
     }
 }
 
-#[cfg(any(feature = "serde"))]
+#[cfg(feature = "serde")]
 pub(crate) mod serde_paramsstring {
     use core::fmt;
     use password_hash::ParamsString;

--- a/aucpace/tests/test_key_agreement.rs
+++ b/aucpace/tests/test_key_agreement.rs
@@ -7,8 +7,8 @@ use rand_core::OsRng;
 use scrypt::{Params, Scrypt};
 use sha2::Sha512;
 
-const USERNAME: &'static [u8] = b"jlpicard_1701";
-const PASSWORD: &'static [u8] = b"g04tEd_c4pT41N";
+const USERNAME: &[u8] = b"jlpicard_1701";
+const PASSWORD: &[u8] = b"g04tEd_c4pT41N";
 const CI: &[u8] = b"test_channel_identifier";
 const PRE_SSID: &[u8] = b"bestest_ssid_ever_i_promise";
 const K1: usize = 16;

--- a/aucpace/tests/test_key_agreement_partial_aug.rs
+++ b/aucpace/tests/test_key_agreement_partial_aug.rs
@@ -9,8 +9,8 @@ use rand_core::OsRng;
 use scrypt::{Params, Scrypt};
 use sha2::Sha512;
 
-const USERNAME: &'static [u8] = b"jlpicard_1701";
-const PASSWORD: &'static [u8] = b"g04tEd_c4pT41N";
+const USERNAME: &[u8] = b"jlpicard_1701";
+const PASSWORD: &[u8] = b"g04tEd_c4pT41N";
 const CI: &[u8] = b"test_channel_identifier";
 const PRE_SSID: &[u8] = b"bestest_ssid_ever_i_promise";
 const K1: usize = 16;
@@ -58,7 +58,7 @@ impl PartialAugDatabase for SingleUserDatabase {
         username: &[u8],
     ) -> Option<(Self::PrivateKey, Self::PublicKey)> {
         match &self.user {
-            Some(stored_user) if stored_user == username => self.long_term_keypair.clone(),
+            Some(stored_user) if stored_user == username => self.long_term_keypair,
             _ => None,
         }
     }

--- a/aucpace/tests/test_key_agreement_strong.rs
+++ b/aucpace/tests/test_key_agreement_strong.rs
@@ -7,8 +7,8 @@ use rand_core::OsRng;
 use scrypt::{Params, Scrypt};
 use sha2::Sha512;
 
-const USERNAME: &'static [u8] = b"jlpicard_1701";
-const PASSWORD: &'static [u8] = b"g04tEd_c4pT41N";
+const USERNAME: &[u8] = b"jlpicard_1701";
+const PASSWORD: &[u8] = b"g04tEd_c4pT41N";
 const CI: &[u8] = b"test_channel_identifier";
 const PRE_SSID: &[u8] = b"bestest_ssid_ever_i_promise";
 const K1: usize = 16;

--- a/aucpace/tests/test_key_agreement_strong_partial_aug.rs
+++ b/aucpace/tests/test_key_agreement_strong_partial_aug.rs
@@ -9,8 +9,8 @@ use rand_core::OsRng;
 use scrypt::{Params, Scrypt};
 use sha2::Sha512;
 
-const USERNAME: &'static [u8] = b"jlpicard_1701";
-const PASSWORD: &'static [u8] = b"g04tEd_c4pT41N";
+const USERNAME: &[u8] = b"jlpicard_1701";
+const PASSWORD: &[u8] = b"g04tEd_c4pT41N";
 const CI: &[u8] = b"test_channel_identifier";
 const PRE_SSID: &[u8] = b"bestest_ssid_ever_i_promise";
 const K1: usize = 16;
@@ -59,7 +59,7 @@ impl PartialAugDatabase for SingleUserDatabase {
         username: &[u8],
     ) -> Option<(Self::PrivateKey, Self::PublicKey)> {
         match &self.user {
-            Some(stored_user) if stored_user == username => self.long_term_keypair.clone(),
+            Some(stored_user) if stored_user == username => self.long_term_keypair,
             _ => None,
         }
     }

--- a/spake2/src/ed25519.rs
+++ b/spake2/src/ed25519.rs
@@ -129,7 +129,7 @@ fn ed25519_hash_to_scalar(s: &[u8]) -> c2_Scalar {
 }
 
 /// Hash `idA` and `idB` identities.
-pub(crate) fn hash_ab(
+pub fn hash_ab(
     password_vec: &[u8],
     id_a: &[u8],
     id_b: &[u8],
@@ -173,7 +173,7 @@ pub(crate) fn hash_ab(
 }
 
 /// Hash symmetric identities.
-pub(crate) fn hash_symmetric(
+pub fn hash_symmetric(
     password_vec: &[u8],
     id_s: &[u8],
     msg_u: &[u8],

--- a/spake2/src/error.rs
+++ b/spake2/src/error.rs
@@ -21,9 +21,9 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::BadSide => fmt.write_str("bad side"),
-            Error::CorruptMessage => fmt.write_str("corrupt message"),
-            Error::WrongLength => fmt.write_str("invalid length"),
+            Self::BadSide => fmt.write_str("bad side"),
+            Self::CorruptMessage => fmt.write_str("corrupt message"),
+            Self::WrongLength => fmt.write_str("invalid length"),
         }
     }
 }

--- a/spake2/tests/spake2.rs
+++ b/spake2/tests/spake2.rs
@@ -46,6 +46,7 @@ fn test_reflected_message() {
 }
 
 #[test]
+#[allow(clippy::slow_vector_initialization)]
 fn test_bad_length() {
     let (s1, msg1) = Spake2::<Ed25519Group>::start_a(
         &Password::new(b"password"),

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "pake", "authentication"]
 categories = ["cryptography", "authentication"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.61"
 
 [dependencies]
 num-bigint = "0.4"

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "pake", "authentication"]
 categories = ["cryptography", "authentication"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61.0"
 
 [dependencies]
 num-bigint = "0.4"

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srp"
-version = "0.6.0"
+version = "0.7.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 description = "Secure Remote Password (SRP) protocol implementation"

--- a/srp/README.md
+++ b/srp/README.md
@@ -32,7 +32,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.60** or higher.
+Rust **1.61.0** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.

--- a/srp/README.md
+++ b/srp/README.md
@@ -32,7 +32,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-Rust **1.61.0** or higher.
+Rust **1.61** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.

--- a/srp/src/types.rs
+++ b/srp/src/types.rs
@@ -12,11 +12,11 @@ pub enum SrpAuthError {
 impl fmt::Display for SrpAuthError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SrpAuthError::IllegalParameter(param) => {
-                write!(f, "illegal_parameter: bad '{}' value", param)
+            Self::IllegalParameter(param) => {
+                write!(f, "illegal_parameter: bad '{param}' value")
             }
-            SrpAuthError::BadRecordMac(param) => {
-                write!(f, "bad_record_mac: incorrect '{}'  proof", param)
+            Self::BadRecordMac(param) => {
+                write!(f, "bad_record_mac: incorrect '{param}'  proof")
             }
         }
     }

--- a/srp/src/utils.rs
+++ b/srp/src/utils.rs
@@ -38,8 +38,8 @@ pub fn compute_m1<D: Digest>(a_pub: &[u8], b_pub: &[u8], key: &[u8]) -> Output<D
 // M2 = H(A, M1, K)
 pub fn compute_m2<D: Digest>(a_pub: &[u8], m1: &Output<D>, key: &[u8]) -> Output<D> {
     let mut d = D::new();
-    d.update(&a_pub);
-    d.update(&m1);
-    d.update(&key);
+    d.update(a_pub);
+    d.update(m1);
+    d.update(key);
     d.finalize()
 }

--- a/srp/src/utils.rs
+++ b/srp/src/utils.rs
@@ -4,6 +4,7 @@ use num_bigint::BigUint;
 use crate::types::SrpGroup;
 
 // u = H(PAD(A) | PAD(B))
+#[must_use]
 pub fn compute_u<D: Digest>(a_pub: &[u8], b_pub: &[u8]) -> BigUint {
     let mut u = D::new();
     u.update(a_pub);
@@ -12,6 +13,7 @@ pub fn compute_u<D: Digest>(a_pub: &[u8], b_pub: &[u8]) -> BigUint {
 }
 
 // k = H(N | PAD(g))
+#[must_use]
 pub fn compute_k<D: Digest>(params: &SrpGroup) -> BigUint {
     let n = params.n.to_bytes_be();
     let g_bytes = params.g.to_bytes_be();
@@ -27,6 +29,7 @@ pub fn compute_k<D: Digest>(params: &SrpGroup) -> BigUint {
 
 // M1 = H(A, B, K) this doesn't follow the spec but apparently no one does for M1
 // M1 should equal =  H(H(N) XOR H(g) | H(U) | s | A | B | K) according to the spec
+#[must_use]
 pub fn compute_m1<D: Digest>(a_pub: &[u8], b_pub: &[u8], key: &[u8]) -> Output<D> {
     let mut d = D::new();
     d.update(a_pub);
@@ -36,6 +39,7 @@ pub fn compute_m1<D: Digest>(a_pub: &[u8], b_pub: &[u8], key: &[u8]) -> Output<D
 }
 
 // M2 = H(A, M1, K)
+#[must_use]
 pub fn compute_m2<D: Digest>(a_pub: &[u8], m1: &Output<D>, key: &[u8]) -> Output<D> {
     let mut d = D::new();
     d.update(a_pub);


### PR DESCRIPTION
While playing around in the workspace (`SPAKE2` specifically), I noticed that there were a tonne of clippy warnings so I decided to fix them all.

~~My only concern is the silencing of `write` via `#[allow(clippy::unused_io_amount)]` - I wonder if changing all of those writes to `write_all` would produce more-than-negligible performance losses.~~ These were changed to `write_all` for correctness.

This changes the MSRV of `srp` and `aucpace` from `1.60.0` to `1.61.0` otherwise they won't build with some `const fn`s ([#93706](https://github.com/rust-lang/rust/issues/93706) was added in `1.61.0`)