### PR TITLE
Set min version of serde to 1.0.184

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,9 +434,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/aucpace/CHANGELOG.md
+++ b/aucpace/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
-### Changed
-- Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#145])
-
-[#145]: https://github.com/RustCrypto/PAKEs/pull/145
-[serde-rs/serde#2538]: https://github.com/serde-rs/serde/issues/2538
-
 ## 0.1.1 (2023-07-27)
 ### Changed
 - Bump `curve25519-dalek` to v4.0 release ([#138])

--- a/aucpace/Cargo.toml
+++ b/aucpace/Cargo.toml
@@ -23,8 +23,7 @@ password-hash = { version = "0.5", default-features = false, features = [
     "rand_core",
 ] }
 rand_core = { version = "0.6", default-features = false }
-# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1, <1.0.172", default-features = false, optional = true, features = [
+serde = { version = "1.0.184", default-features = false, optional = true, features = [
     "derive",
 ] }
 serde-byte-array = { version = "0.1", optional = true }


### PR DESCRIPTION
In 1.0.184 `serde` was [un-blobbed](https://github.com/serde-rs/serde/releases/tag/v1.0.184). To prevent accidental pulling of the blobbed versions 1.0.184 will be used as a min version.

Relevant PR: #145 