### PR TITLE
Update Cargo.toml

### DIFF
--- a/spake2/Cargo.toml
+++ b/spake2/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
-curve25519-dalek = { version = "4", default-features = false, features = ["rand_core"] }
+curve25519-dalek = { version = "4.1.3", default-features = false, features = ["rand_core"] }
 rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 hkdf = { version = "0.12", default-features = false }


### PR DESCRIPTION
Bumps the dependency to at least 4.1.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0344.html) 

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)