### PR TITLE
Fix security audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,6 @@
+# https://github.com/RustSec/cargo-audit/blob/master/audit.toml.example
+
+[advisories]
+ignore = [
+    "RUSTSEC-2023-0089", # atomic-polyfill is unmaintained (used by `postcard`)
+]

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.85.1
           components: clippy
       - run: cargo clippy --all -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crypto-common"


### PR DESCRIPTION
Ignores RUSTSEC-2023-0089 until `postcard` updates to `heapless` v0.8