### PR TITLE
Remove `bincode` dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,6 @@ dependencies = [
 name = "aucpace"
 version = "0.2.0-pre"
 dependencies = [
- "bincode",
  "curve25519-dalek",
  "password-hash",
  "postcard",
@@ -45,15 +44,6 @@ name = "bencher"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "block-buffer"
@@ -207,6 +197,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "fiat-crypto"
@@ -374,6 +376,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
 dependencies = [
  "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
  "heapless",
  "serde",
 ]

--- a/aucpace/Cargo.toml
+++ b/aucpace/Cargo.toml
@@ -28,10 +28,9 @@ scrypt = { version = "0.12.0-rc.3", default-features = false, optional = true, f
 sha2 = { version = "0.11.0-rc.3", default-features = false, optional = true }
 
 [dev-dependencies]
-bincode = "1"
 curve25519-dalek = { version = "5.0.0-pre.1", features = ["digest", "rand_core"] }
 password-hash = { version = "0.6.0-rc.2", features = ["rand_core"] }
-postcard = "1"
+postcard = { version = "1", features = ["use-std"] }
 scrypt = { version = "0.12.0-rc.3", features = ["simple"] }
 sha2 = "0.11.0-rc.3"
 

--- a/aucpace/examples/key_agreement.rs
+++ b/aucpace/examples/key_agreement.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 /// function like macro to wrap sending data over a tcp stream, returns the number of bytes sent
 macro_rules! send {
     ($stream:ident, $msg:ident) => {{
-        let serialised = bincode::serialize(&$msg).unwrap();
+        let serialised = postcard::to_stdvec(&$msg).unwrap();
         $stream.write_all(&serialised).unwrap();
         serialised.len()
     }};
@@ -26,7 +26,7 @@ macro_rules! recv {
     ($stream:ident, $buf:ident) => {{
         let bytes_received = $stream.read(&mut $buf).unwrap();
         let received = &$buf[..bytes_received];
-        bincode::deserialize(received).unwrap()
+        postcard::from_bytes(received).unwrap()
     }};
 }
 

--- a/aucpace/examples/key_agreement_partial_aug.rs
+++ b/aucpace/examples/key_agreement_partial_aug.rs
@@ -18,7 +18,7 @@ use std::time::Instant;
 /// function like macro to wrap sending data over a tcp stream, returns the number of bytes sent
 macro_rules! send {
     ($stream:ident, $msg:ident) => {{
-        let serialised = bincode::serialize(&$msg).unwrap();
+        let serialised = postcard::to_stdvec(&$msg).unwrap();
         $stream.write_all(&serialised).unwrap();
         serialised.len()
     }};
@@ -29,7 +29,7 @@ macro_rules! recv {
     ($stream:ident, $buf:ident) => {{
         let bytes_received = $stream.read(&mut $buf).unwrap();
         let received = &$buf[..bytes_received];
-        bincode::deserialize(received).unwrap()
+        postcard::from_bytes(received).unwrap()
     }};
 }
 

--- a/aucpace/examples/key_agreement_strong.rs
+++ b/aucpace/examples/key_agreement_strong.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 /// function like macro to wrap sending data over a tcp stream, returns the number of bytes sent
 macro_rules! send {
     ($stream:ident, $msg:ident) => {{
-        let serialised = bincode::serialize(&$msg).unwrap();
+        let serialised = postcard::to_stdvec(&$msg).unwrap();
         $stream.write_all(&serialised).unwrap();
         serialised.len()
     }};
@@ -28,7 +28,7 @@ macro_rules! recv {
     ($stream:ident, $buf:ident) => {{
         let bytes_received = $stream.read(&mut $buf).unwrap();
         let received = &$buf[..bytes_received];
-        bincode::deserialize(received).unwrap()
+        postcard::from_bytes(received).unwrap()
     }};
 }
 


### PR DESCRIPTION
`bincode` is unmaintained. See https://crates.io/crates/bincode/3.0.0