### PR TITLE
srp: preliminary `no_std` support

### DIFF
--- a/srp/src/client.rs
+++ b/srp/src/client.rs
@@ -100,15 +100,16 @@
 //! ```
 //!
 
-use std::marker::PhantomData;
+use alloc::{borrow::ToOwned, vec::Vec};
+use core::marker::PhantomData;
 
 use digest::{Digest, Output};
 use num_bigint::BigUint;
 use subtle::ConstantTimeEq;
 
-use crate::types::{SrpAuthError, SrpGroup};
-use crate::utils::{
-    compute_hash, compute_k, compute_m1, compute_m1_rfc5054, compute_m2, compute_u,
+use crate::{
+    types::{SrpAuthError, SrpGroup},
+    utils::{compute_hash, compute_k, compute_m1, compute_m1_rfc5054, compute_m2, compute_u},
 };
 
 /// SRP client state before handshake with the server.

--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -1,6 +1,10 @@
-#![allow(clippy::many_single_char_names)]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![no_std]
 #![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
+)]
+#![allow(clippy::many_single_char_names)]
 
 //! # Usage
 //! Add `srp` dependency to your `Cargo.toml`:
@@ -35,7 +39,7 @@
 //! - `I` — user identity (username)
 //! - `P` — user password
 //! - `H` — one-way hash function
-//! - `PH` — password hashing algroithm, in the RFC 5054 described as
+//! - `PH` — password hashing algorithm, in the RFC 5054 described as
 //! `H(s ‖ H(I ‖ ":" ‖ P))`
 //! - `^` — (modular) exponentiation
 //! - `‖` — concatenation
@@ -49,6 +53,9 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/Secure_Remote_Password_protocol
 //! [2]: https://tools.ietf.org/html/rfc5054
+
+#[macro_use]
+extern crate alloc;
 
 pub mod client;
 pub mod groups;

--- a/srp/src/server.rs
+++ b/srp/src/server.rs
@@ -77,7 +77,8 @@
 //! send_proof(verifier.proof());
 //! ```
 //!
-use std::marker::PhantomData;
+use alloc::{borrow::ToOwned, vec::Vec};
+use core::marker::PhantomData;
 
 use digest::{Digest, Output};
 use num_bigint::BigUint;

--- a/srp/src/types.rs
+++ b/srp/src/types.rs
@@ -1,6 +1,8 @@
 //! Additional SRP types.
+
+use alloc::string::String;
+use core::fmt;
 use num_bigint::BigUint;
-use std::fmt;
 
 /// SRP authentication error.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/srp/src/utils.rs
+++ b/srp/src/utils.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use digest::{Digest, Output};
 use num_bigint::BigUint;
 


### PR DESCRIPTION
Adds the `#![no_std]` attribute and changes references to `std` to be `alloc`/`core` instead