### PR TITLE
Replace `rand` with `getrandom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ name = "aucpace"
 version = "0.2.0-pre"
 dependencies = [
  "curve25519-dalek",
+ "getrandom",
  "password-hash",
  "postcard",
- "rand",
  "rand_core",
  "scrypt",
  "serde",
@@ -65,17 +65,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chacha20"
-version = "0.10.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895fb33c1ad22da4bc79d37c0bddff8aee2ba4575705345eb73b8ffbc386074"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core",
-]
 
 [[package]]
 name = "cipher"
@@ -388,17 +377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.10.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bccc05ac8fad6ee391f3cc6725171817eed960345e2fb42ad229d486c1ca2d98"
-dependencies = [
- "chacha20",
- "getrandom",
- "rand_core",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.10.0-rc-3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,10 +493,10 @@ version = "0.5.0-pre"
 dependencies = [
  "bencher",
  "curve25519-dalek",
+ "getrandom",
  "hex",
  "hkdf",
  "num-bigint",
- "rand",
  "rand_core",
  "sha2",
 ]
@@ -537,11 +515,11 @@ name = "srp"
 version = "0.7.0-pre.0"
 dependencies = [
  "digest",
+ "getrandom",
  "hex-literal",
  "lazy_static",
  "num-bigint",
  "num-traits",
- "rand",
  "sha1",
  "sha2",
  "subtle",

--- a/aucpace/Cargo.toml
+++ b/aucpace/Cargo.toml
@@ -21,7 +21,7 @@ rand_core = { version = "0.10.0-rc-3", default-features = false }
 subtle = { version = "2.4", default-features = false }
 
 # optional dependencies
-rand = { version = "0.10.0-rc.6", optional = true }
+getrandom = { version = "0.4.0-rc.0", optional = true, features = ["sys_rng"] }
 serde = { version = "1.0.184", default-features = false, optional = true, features = ["derive"] }
 serde-byte-array = { version = "0.1", optional = true }
 scrypt = { version = "0.12.0-rc.8", default-features = false, optional = true, features = ["phc"] }
@@ -35,7 +35,7 @@ scrypt = { version = "0.12.0-rc.8", features = ["phc"] }
 sha2 = "0.11.0-rc.3"
 
 [features]
-default = ["rand", "scrypt", "sha2"]
+default = ["getrandom", "scrypt", "sha2"]
 alloc = []
 
 partial_augmentation = []

--- a/aucpace/src/client.rs
+++ b/aucpace/src/client.rs
@@ -1052,11 +1052,11 @@ mod tests {
     #[allow(unused)]
     use super::*;
 
-    #[cfg(all(feature = "rand", feature = "sha2"))]
+    #[cfg(all(feature = "getrandom", feature = "sha2"))]
     use crate::{SysRng, rand_core::TryRngCore};
 
     #[test]
-    #[cfg(all(feature = "alloc", feature = "rand", feature = "scrypt"))]
+    #[cfg(all(feature = "alloc", feature = "getrandom", feature = "scrypt"))]
     fn test_hash_password_no_std_and_alloc_agree() {
         use scrypt::{Params, Scrypt};
 
@@ -1083,7 +1083,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "rand", feature = "sha2"))]
+    #[cfg(all(feature = "getrandom", feature = "sha2"))]
     fn test_client_doesnt_accept_insecure_ssid() {
         use crate::Client;
 

--- a/aucpace/src/lib.rs
+++ b/aucpace/src/lib.rs
@@ -110,17 +110,17 @@ pub use self::database::PartialAugDatabase;
 #[cfg(feature = "strong_aucpace")]
 pub use self::database::StrongDatabase;
 
-#[cfg(feature = "rand")]
-pub use rand::rngs::SysRng;
+#[cfg(feature = "getrandom")]
+pub use getrandom::SysRng;
 
 /// Infallible version of `SysRng` which panics on error
-#[cfg(feature = "rand")]
+#[cfg(feature = "getrandom")]
 pub type UnwrapSysRng = rand_core::UnwrapErr<SysRng>;
 
 /// Default Server instantiation with `SHA512`, `SysRng` and a nonce size of 16 bytes
-#[cfg(all(feature = "sha2", feature = "rand"))]
+#[cfg(all(feature = "sha2", feature = "getrandom"))]
 pub type Server = AuCPaceServer<sha2::Sha512, UnwrapSysRng, 16>;
 
 /// Default Client instantiation with `SHA512`, `Scrypt`, `SysRng` and a nonce size of 16 bytes
-#[cfg(all(feature = "scrypt", feature = "sha2", feature = "rand"))]
+#[cfg(all(feature = "scrypt", feature = "sha2", feature = "getrandom"))]
 pub type Client = AuCPaceClient<sha2::Sha512, scrypt::Scrypt, UnwrapSysRng, 16>;

--- a/aucpace/src/server.rs
+++ b/aucpace/src/server.rs
@@ -733,11 +733,11 @@ mod tests {
     #[allow(unused)]
     use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 
-    #[cfg(all(feature = "sha2", feature = "rand"))]
+    #[cfg(all(feature = "sha2", feature = "getrandom"))]
     use crate::{SysRng, rand_core::TryRngCore};
 
     #[test]
-    #[cfg(all(feature = "sha2", feature = "rand"))]
+    #[cfg(all(feature = "sha2", feature = "getrandom"))]
     fn test_server_doesnt_accept_insecure_ssid() {
         use crate::Server;
         let mut server = Server::new(SysRng.unwrap_err());
@@ -837,7 +837,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "sha2", feature = "rand", feature = "strong_aucpace"))]
+    #[cfg(all(feature = "sha2", feature = "getrandom", feature = "strong_aucpace"))]
     fn test_server_doesnt_accept_invalid_uq() {
         use crate::utils::H0;
         use curve25519_dalek::traits::Identity;
@@ -863,7 +863,7 @@ mod tests {
     #[cfg(all(
         feature = "partial_augmentation",
         feature = "sha2",
-        feature = "rand",
+        feature = "getrandom",
         feature = "strong_aucpace"
     ))]
     fn test_server_doesnt_accept_invalid_uq_partial() {

--- a/aucpace/tests/test_key_agreement.rs
+++ b/aucpace/tests/test_key_agreement.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "alloc", feature = "rand"))]
+#![cfg(all(feature = "alloc", feature = "getrandom"))]
 
 use aucpace::{
     Client, ClientMessage, Database, Result, Server, ServerMessage, SysRng,

--- a/aucpace/tests/test_key_agreement_partial_aug.rs
+++ b/aucpace/tests/test_key_agreement_partial_aug.rs
@@ -1,4 +1,8 @@
-#![cfg(all(feature = "alloc", feature = "partial_augmentation", feature = "rand"))]
+#![cfg(all(
+    feature = "alloc",
+    feature = "partial_augmentation",
+    feature = "getrandom"
+))]
 
 use aucpace::{
     Client, ClientMessage, Database, Error, PartialAugDatabase, Result, Server, ServerMessage,

--- a/aucpace/tests/test_key_agreement_strong.rs
+++ b/aucpace/tests/test_key_agreement_strong.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "alloc", feature = "rand", feature = "strong_aucpace"))]
+#![cfg(all(feature = "alloc", feature = "getrandom", feature = "strong_aucpace"))]
 
 use aucpace::{
     Client, ClientMessage, Result, Server, ServerMessage, StrongDatabase, SysRng,

--- a/aucpace/tests/test_key_agreement_strong_partial_aug.rs
+++ b/aucpace/tests/test_key_agreement_strong_partial_aug.rs
@@ -1,7 +1,7 @@
 #![cfg(all(
     feature = "alloc",
     feature = "partial_augmentation",
-    feature = "rand",
+    feature = "getrandom",
     feature = "strong_aucpace"
 ))]
 

--- a/spake2/Cargo.toml
+++ b/spake2/Cargo.toml
@@ -21,7 +21,7 @@ sha2 = { version = "0.11.0-rc.3", default-features = false }
 hkdf = { version = "0.13.0-rc.3", default-features = false }
 
 # optional dependencies
-rand = { version = "0.10.0-rc.6", optional = true }
+getrandom = { version = "0.4.0-rc.0", optional = true, features = ["sys_rng"] }
 
 [dev-dependencies]
 bencher = "0.1"

--- a/spake2/src/lib.rs
+++ b/spake2/src/lib.rs
@@ -40,8 +40,8 @@
 //!
 //! Thus a client-side program start with:
 //!
-#![cfg_attr(feature = "rand", doc = "```")]
-#![cfg_attr(not(feature = "rand"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! use spake2::{Ed25519Group, Identity, Password, Spake2};
 //! # fn send(msg: &[u8]) {}
 //! let (s1, outbound_msg) = Spake2::<Ed25519Group>::start_a(
@@ -57,8 +57,8 @@
 //!
 //! while the server-side might do:
 //!
-#![cfg_attr(feature = "rand", doc = "```")]
-#![cfg_attr(not(feature = "rand"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn send(msg: &[u8]) {}
 //! use spake2::{Ed25519Group, Identity, Password, Spake2};
 //! let (s1, outbound_msg) = Spake2::<Ed25519Group>::start_b(
@@ -102,8 +102,8 @@
 //!
 //! Carol does:
 //!
-#![cfg_attr(feature = "rand", doc = "```")]
-#![cfg_attr(not(feature = "rand"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn send(msg: &[u8]) {}
 //! use spake2::{Ed25519Group, Identity, Password, Spake2};
 //! let (s1, outbound_msg) = Spake2::<Ed25519Group>::start_symmetric(
@@ -118,8 +118,8 @@
 //!
 //! Dave does exactly the same:
 //!
-#![cfg_attr(feature = "rand", doc = "```")]
-#![cfg_attr(not(feature = "rand"), doc = "```ignore")]
+#![cfg_attr(feature = "getrandom", doc = "```")]
+#![cfg_attr(not(feature = "getrandom"), doc = "```ignore")]
 //! # fn send(msg: &[u8]) {}
 //! use spake2::{Ed25519Group, Identity, Password, Spake2};
 //! let (s1, outbound_msg) = Spake2::<Ed25519Group>::start_symmetric(
@@ -250,11 +250,11 @@ use core::{fmt, ops::Deref, str};
 use curve25519_dalek::{edwards::EdwardsPoint as c2_Element, scalar::Scalar as c2_Scalar};
 use rand_core::CryptoRng;
 
-#[cfg(feature = "rand")]
-pub use rand::rngs::SysRng;
+#[cfg(feature = "getrandom")]
+pub use getrandom::SysRng;
 
-#[cfg(feature = "rand")]
-use rand::TryRngCore;
+#[cfg(feature = "getrandom")]
+use rand_core::TryRngCore;
 
 /// Password type.
 // TODO(tarcieri): avoid allocation?
@@ -320,7 +320,7 @@ impl<G: Group> Spake2<G> {
     /// Start with identity `idA`.
     ///
     /// Uses the system RNG.
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "getrandom")]
     #[must_use]
     pub fn start_a(password: &Password, id_a: &Identity, id_b: &Identity) -> (Self, Vec<u8>) {
         Self::start_a_with_rng(password, id_a, id_b, SysRng.unwrap_mut())
@@ -329,7 +329,7 @@ impl<G: Group> Spake2<G> {
     /// Start with identity `idB`.
     ///
     /// Uses the system RNG.
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "getrandom")]
     #[must_use]
     pub fn start_b(password: &Password, id_a: &Identity, id_b: &Identity) -> (Self, Vec<u8>) {
         Self::start_b_with_rng(password, id_a, id_b, SysRng.unwrap_mut())
@@ -338,7 +338,7 @@ impl<G: Group> Spake2<G> {
     /// Start with symmetric identity.
     ///
     /// Uses the system RNG.
-    #[cfg(feature = "rand")]
+    #[cfg(feature = "getrandom")]
     #[must_use]
     pub fn start_symmetric(password: &Password, id_s: &Identity) -> (Self, Vec<u8>) {
         Self::start_symmetric_with_rng(password, id_s, SysRng.unwrap_mut())

--- a/spake2/tests/spake2.rs
+++ b/spake2/tests/spake2.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "rand")]
+#![cfg(feature = "getrandom")]
 
 use spake2::{Ed25519Group, Error, Identity, Password, Spake2};
 

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -19,8 +19,8 @@ lazy_static = "1.2"
 subtle = "2.4"
 
 [dev-dependencies]
+getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 hex-literal = "1"
 num-traits = "0.2"
-rand = "0.10.0-rc.6"
 sha1 = "0.11.0-rc.3"
 sha2 = "0.11.0-rc.3"

--- a/srp/tests/srp.rs
+++ b/srp/tests/srp.rs
@@ -1,12 +1,12 @@
-use rand::RngCore;
+use getrandom::{
+    SysRng,
+    rand_core::{RngCore, TryRngCore},
+};
 use sha2::Sha256;
-use srp::client::SrpClient;
-
-use srp::groups::G_2048;
-use srp::server::SrpServer;
+use srp::{client::SrpClient, groups::G_2048, server::SrpServer};
 
 fn auth_test(true_pwd: &[u8], auth_pwd: &[u8]) {
-    let mut rng = rand::rng();
+    let mut rng = SysRng.unwrap_err();
     let username = b"alice";
 
     // Client instance creation
@@ -69,7 +69,7 @@ fn auth_test(true_pwd: &[u8], auth_pwd: &[u8]) {
 }
 
 fn auth_test_rfc5054(true_pwd: &[u8], auth_pwd: &[u8]) {
-    let mut rng = rand::rng();
+    let mut rng = SysRng.unwrap_err();
     let username = b"alice";
 
     // Client instance creation


### PR DESCRIPTION
We're only using `rand` for `SysRng`, which we can source directly from `getrandom` with fewer overall dependencies.