### PR TITLE
srp: migrate from `num-bigint` to `crypto-bigint`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11ed919bd3bae4af5ab56372b627dfc32622aba6cec36906e8ab46746037c9d"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,12 +120,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.0-rc.16"
+source = "git+https://github.com/RustCrypto/crypto-bigint#b047ab0a78a6542190b47107ef15be108b110a0b"
+dependencies = [
+ "ctutils",
+ "num-traits",
+ "rand_core",
+ "serdect",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41b8986f836d4aeb30ccf4c9d3bd562fd716074cfd7fc4a2948359fbd21ed809"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -260,12 +292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +333,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "password-hash"
@@ -466,6 +498,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,12 +556,11 @@ dependencies = [
 name = "srp"
 version = "0.7.0-pre.0"
 dependencies = [
+ "crypto-bigint",
  "digest",
  "getrandom",
  "hex-literal",
- "lazy_static",
- "num-bigint",
- "num-traits",
+ "once_cell",
  "sha1",
  "sha2",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io.crypto-bigint]
+git = "https://github.com/RustCrypto/crypto-bigint"

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -13,14 +13,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-num-bigint = "0.4"
+crypto-bigint = { version = "0.7.0-rc.16", features = ["alloc"] }
 digest = "0.11.0-rc.5"
-lazy_static = "1.2"
+once_cell = "1"
 subtle = "2.4"
 
 [dev-dependencies]
 getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 hex-literal = "1"
-num-traits = "0.2"
 sha1 = "0.11.0-rc.3"
 sha2 = "0.11.0-rc.3"

--- a/srp/src/groups.rs
+++ b/srp/src/groups.rs
@@ -1,57 +1,58 @@
 //! Groups from [RFC 5054](https://tools.ietf.org/html/rfc5054)
 //!
 //! It is strongly recommended to use them instead of custom generated
-//! groups. Additionally it is not recommended to use `G_1024` and `G_1536`,
+//! groups. Additionally, it is not recommended to use `G_1024` and `G_1536`,
 //! they are provided only for compatibility with the legacy software.
+
 use crate::types::SrpGroup;
-use lazy_static::lazy_static;
-use num_bigint::BigUint;
+use crypto_bigint::BoxedUint;
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    pub static ref G_1024: SrpGroup = SrpGroup {
-        n: BigUint::from_bytes_be(include_bytes!("groups/1024.bin")),
-        g: BigUint::from_bytes_be(&[2]),
-    };
-}
+pub static G_1024: Lazy<SrpGroup> = Lazy::new(|| {
+    SrpGroup::new(
+        BoxedUint::from_be_slice_vartime(include_bytes!("groups/1024.bin")),
+        BoxedUint::from_be_slice_vartime(&[2]),
+    )
+});
 
-lazy_static! {
-    pub static ref G_1536: SrpGroup = SrpGroup {
-        n: BigUint::from_bytes_be(include_bytes!("groups/1536.bin")),
-        g: BigUint::from_bytes_be(&[2]),
-    };
-}
+pub static G_1536: Lazy<SrpGroup> = Lazy::new(|| {
+    SrpGroup::new(
+        BoxedUint::from_be_slice_vartime(include_bytes!("groups/1536.bin")),
+        BoxedUint::from_be_slice_vartime(&[2]),
+    )
+});
 
-lazy_static! {
-    pub static ref G_2048: SrpGroup = SrpGroup {
-        n: BigUint::from_bytes_be(include_bytes!("groups/2048.bin")),
-        g: BigUint::from_bytes_be(&[2]),
-    };
-}
+pub static G_2048: Lazy<SrpGroup> = Lazy::new(|| {
+    SrpGroup::new(
+        BoxedUint::from_be_slice_vartime(include_bytes!("groups/2048.bin")),
+        BoxedUint::from_be_slice_vartime(&[2]),
+    )
+});
 
-lazy_static! {
-    pub static ref G_3072: SrpGroup = SrpGroup {
-        n: BigUint::from_bytes_be(include_bytes!("groups/3072.bin")),
-        g: BigUint::from_bytes_be(&[5]),
-    };
-}
+pub static G_3072: Lazy<SrpGroup> = Lazy::new(|| {
+    SrpGroup::new(
+        BoxedUint::from_be_slice_vartime(include_bytes!("groups/3072.bin")),
+        BoxedUint::from_be_slice_vartime(&[5]),
+    )
+});
 
-lazy_static! {
-    pub static ref G_4096: SrpGroup = SrpGroup {
-        n: BigUint::from_bytes_be(include_bytes!("groups/4096.bin")),
-        g: BigUint::from_bytes_be(&[5]),
-    };
-}
+pub static G_4096: Lazy<SrpGroup> = Lazy::new(|| {
+    SrpGroup::new(
+        BoxedUint::from_be_slice_vartime(include_bytes!("groups/4096.bin")),
+        BoxedUint::from_be_slice_vartime(&[5]),
+    )
+});
 
-lazy_static! {
-    pub static ref G_6144: SrpGroup = SrpGroup {
-        n: BigUint::from_bytes_be(include_bytes!("groups/6144.bin")),
-        g: BigUint::from_bytes_be(&[5]),
-    };
-}
+pub static G_6144: Lazy<SrpGroup> = Lazy::new(|| {
+    SrpGroup::new(
+        BoxedUint::from_be_slice_vartime(include_bytes!("groups/6144.bin")),
+        BoxedUint::from_be_slice_vartime(&[5]),
+    )
+});
 
-lazy_static! {
-    pub static ref G_8192: SrpGroup = SrpGroup {
-        n: BigUint::from_bytes_be(include_bytes!("groups/8192.bin")),
-        g: BigUint::from_bytes_be(&[19]),
-    };
-}
+pub static G_8192: Lazy<SrpGroup> = Lazy::new(|| {
+    SrpGroup::new(
+        BoxedUint::from_be_slice_vartime(include_bytes!("groups/8192.bin")),
+        BoxedUint::from_be_slice_vartime(&[19]),
+    )
+});

--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+//#![no_std]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",

--- a/srp/tests/bad_public.rs
+++ b/srp/tests/bad_public.rs
@@ -1,5 +1,4 @@
-use num_bigint::BigUint;
-use num_traits::identities::Zero;
+use crypto_bigint::BoxedUint;
 use sha1::Sha1;
 use srp::client::SrpClient;
 use srp::groups::G_1024;
@@ -10,7 +9,7 @@ use srp::server::SrpServer;
 fn bad_a_pub() {
     let server = SrpServer::<Sha1>::new(&G_1024);
     server
-        .process_reply(b"", b"", &BigUint::zero().to_bytes_be())
+        .process_reply(b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();
 }
 
@@ -19,6 +18,6 @@ fn bad_a_pub() {
 fn bad_b_pub() {
     let client = SrpClient::<Sha1>::new(&G_1024);
     client
-        .process_reply(b"", b"", b"", b"", &BigUint::zero().to_bytes_be())
+        .process_reply(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();
 }

--- a/srp/tests/rfc5054.rs
+++ b/srp/tests/rfc5054.rs
@@ -1,5 +1,5 @@
+use crypto_bigint::BoxedUint;
 use hex_literal::hex;
-use num_bigint::BigUint;
 use sha1::Sha1;
 use srp::client::SrpClient;
 use srp::groups::G_1024;
@@ -17,8 +17,8 @@ fn rfc5054() {
     let k = compute_k::<Sha1>(group);
 
     assert_eq!(
-        k.to_bytes_be(),
-        hex!("7556AA04 5AEF2CDD 07ABAF0F 665C3E81 8913186F"),
+        &*k.to_be_bytes_trimmed_vartime(),
+        &hex!("7556AA04 5AEF2CDD 07ABAF0F 665C3E81 8913186F"),
         "bad k value"
     );
 
@@ -26,52 +26,46 @@ fn rfc5054() {
     let x = SrpClient::<Sha1>::compute_x(identity_hash.as_slice(), &s);
 
     assert_eq!(
-        x.to_bytes_be(),
-        hex!("94B7555A ABE9127C C58CCF49 93DB6CF8 4D16C124"),
+        &*x.to_be_bytes_trimmed_vartime(),
+        &hex!("94B7555A ABE9127C C58CCF49 93DB6CF8 4D16C124"),
         "bad x value"
     );
 
     let client = SrpClient::<Sha1>::new(group);
-    let v = client.compute_v(&x);
+    let v = client.compute_g_x(&x);
 
     assert_eq!(
-        v.to_bytes_be(),
-        hex!(
-            "        
-         7E273DE8 696FFC4F 4E337D05 B4B375BE B0DDE156 9E8FA00A 9886D812
-         9BADA1F1 822223CA 1A605B53 0E379BA4 729FDC59 F105B478 7E5186F5
-         C671085A 1447B52A 48CF1970 B4FB6F84 00BBF4CE BFBB1681 52E08AB5
-         EA53D15C 1AFF87B2 B9DA6E04 E058AD51 CC72BFC9 033B564E 26480D78
-         E955A5E2 9E7AB245 DB2BE315 E2099AFB
-         "
+        &*v.to_be_bytes(),
+        &hex!(
+            "7E273DE8 696FFC4F 4E337D05 B4B375BE B0DDE156 9E8FA00A 9886D812
+             9BADA1F1 822223CA 1A605B53 0E379BA4 729FDC59 F105B478 7E5186F5
+             C671085A 1447B52A 48CF1970 B4FB6F84 00BBF4CE BFBB1681 52E08AB5
+             EA53D15C 1AFF87B2 B9DA6E04 E058AD51 CC72BFC9 033B564E 26480D78
+             E955A5E2 9E7AB245 DB2BE315 E2099AFB"
         ),
         "bad v value"
     );
 
-    let a = BigUint::from_bytes_be(&hex!(
-        "
-    60975527 035CF2AD 1989806F 0407210B C81EDC04 E2762A56 AFD529DD
-    DA2D4393"
+    let a = BoxedUint::from_be_slice_vartime(&hex!(
+        "60975527 035CF2AD 1989806F 0407210B C81EDC04 E2762A56 AFD529DD
+         DA2D4393"
     ));
 
-    let b = BigUint::from_bytes_be(&hex!(
-        "
-    E487CB59 D31AC550 471E81F0 0F6928E0 1DDA08E9 74A004F4 9E61F5D1
-    05284D20"
+    let b = BoxedUint::from_be_slice_vartime(&hex!(
+        "E487CB59 D31AC550 471E81F0 0F6928E0 1DDA08E9 74A004F4 9E61F5D1
+         05284D20"
     ));
 
-    let a_pub = client.compute_a_pub(&a);
+    let a_pub = client.compute_g_x(&a);
 
     assert_eq!(
-        a_pub.to_bytes_be(),
-        hex!(
-            "
-         61D5E490 F6F1B795 47B0704C 436F523D D0E560F0 C64115BB 72557EC4
-         4352E890 3211C046 92272D8B 2D1A5358 A2CF1B6E 0BFCF99F 921530EC
-         8E393561 79EAE45E 42BA92AE ACED8251 71E1E8B9 AF6D9C03 E1327F44
-         BE087EF0 6530E69F 66615261 EEF54073 CA11CF58 58F0EDFD FE15EFEA
-         B349EF5D 76988A36 72FAC47B 0769447B
-         "
+        &*a_pub.to_be_bytes(),
+        &hex!(
+            "61D5E490 F6F1B795 47B0704C 436F523D D0E560F0 C64115BB 72557EC4
+             4352E890 3211C046 92272D8B 2D1A5358 A2CF1B6E 0BFCF99F 921530EC
+             8E393561 79EAE45E 42BA92AE ACED8251 71E1E8B9 AF6D9C03 E1327F44
+             BE087EF0 6530E69F 66615261 EEF54073 CA11CF58 58F0EDFD FE15EFEA
+             B349EF5D 76988A36 72FAC47B 0769447B"
         ),
         "bad a_pub value"
     );
@@ -80,55 +74,49 @@ fn rfc5054() {
     let b_pub = server.compute_b_pub(&b, &k, &v);
 
     assert_eq!(
-        b_pub.to_bytes_be(),
-        hex!(
-            "
-         BD0C6151 2C692C0C B6D041FA 01BB152D 4916A1E7 7AF46AE1 05393011
-         BAF38964 DC46A067 0DD125B9 5A981652 236F99D9 B681CBF8 7837EC99
-         6C6DA044 53728610 D0C6DDB5 8B318885 D7D82C7F 8DEB75CE 7BD4FBAA
-         37089E6F 9C6059F3 88838E7A 00030B33 1EB76840 910440B1 B27AAEAE
-         EB4012B7 D7665238 A8E3FB00 4B117B58
-         "
+        &*b_pub.to_be_bytes(),
+        &hex!(
+            "BD0C6151 2C692C0C B6D041FA 01BB152D 4916A1E7 7AF46AE1 05393011
+             BAF38964 DC46A067 0DD125B9 5A981652 236F99D9 B681CBF8 7837EC99
+             6C6DA044 53728610 D0C6DDB5 8B318885 D7D82C7F 8DEB75CE 7BD4FBAA
+             37089E6F 9C6059F3 88838E7A 00030B33 1EB76840 910440B1 B27AAEAE
+             EB4012B7 D7665238 A8E3FB00 4B117B58"
         ),
         "bad b_pub value"
     );
 
-    let u = compute_u::<Sha1>(&a_pub.to_bytes_be(), &b_pub.to_bytes_be());
+    let u = compute_u::<Sha1>(&a_pub.to_be_bytes(), &b_pub.to_be_bytes());
 
     assert_eq!(
-        u.to_bytes_be(),
-        hex!("CE38B959 3487DA98 554ED47D 70A7AE5F 462EF019"),
+        &*u.to_be_bytes_trimmed_vartime(),
+        &hex!("CE38B959 3487DA98 554ED47D 70A7AE5F 462EF019"),
         "bad u value"
     );
 
     assert_eq!(
-        client
+        &*client
             .compute_premaster_secret(&b_pub, &k, &x, &a, &u)
-            .to_bytes_be(),
-        hex!(
-            "
-         B0DC82BA BCF30674 AE450C02 87745E79 90A3381F 63B387AA F271A10D
-         233861E3 59B48220 F7C4693C 9AE12B0A 6F67809F 0876E2D0 13800D6C
-         41BB59B6 D5979B5C 00A172B4 A2A5903A 0BDCAF8A 709585EB 2AFAFA8F
-         3499B200 210DCC1F 10EB3394 3CD67FC8 8A2F39A4 BE5BEC4E C0A3212D
-         C346D7E4 74B29EDE 8A469FFE CA686E5A
-         "
+            .to_be_bytes(),
+        &hex!(
+            "B0DC82BA BCF30674 AE450C02 87745E79 90A3381F 63B387AA F271A10D
+             233861E3 59B48220 F7C4693C 9AE12B0A 6F67809F 0876E2D0 13800D6C
+             41BB59B6 D5979B5C 00A172B4 A2A5903A 0BDCAF8A 709585EB 2AFAFA8F
+             3499B200 210DCC1F 10EB3394 3CD67FC8 8A2F39A4 BE5BEC4E C0A3212D
+             C346D7E4 74B29EDE 8A469FFE CA686E5A"
         ),
         "bad client premaster"
     );
 
     assert_eq!(
-        server
+        &*server
             .compute_premaster_secret(&a_pub, &v, &u, &b)
-            .to_bytes_be(),
-        hex!(
-            "
-         B0DC82BA BCF30674 AE450C02 87745E79 90A3381F 63B387AA F271A10D
-         233861E3 59B48220 F7C4693C 9AE12B0A 6F67809F 0876E2D0 13800D6C
-         41BB59B6 D5979B5C 00A172B4 A2A5903A 0BDCAF8A 709585EB 2AFAFA8F
-         3499B200 210DCC1F 10EB3394 3CD67FC8 8A2F39A4 BE5BEC4E C0A3212D
-         C346D7E4 74B29EDE 8A469FFE CA686E5A
-         "
+            .to_be_bytes(),
+        &hex!(
+            "B0DC82BA BCF30674 AE450C02 87745E79 90A3381F 63B387AA F271A10D
+             233861E3 59B48220 F7C4693C 9AE12B0A 6F67809F 0876E2D0 13800D6C
+             41BB59B6 D5979B5C 00A172B4 A2A5903A 0BDCAF8A 709585EB 2AFAFA8F
+             3499B200 210DCC1F 10EB3394 3CD67FC8 8A2F39A4 BE5BEC4E C0A3212D
+             C346D7E4 74B29EDE 8A469FFE CA686E5A"
         ),
         "bad server premaster"
     );


### PR DESCRIPTION
As noted in #191, the modpow implementation (along with practically everything else) is not constant-time, which could lead to potential sidechannel leakage of secrets.

This migrates the `srp` codebase from `num-bigint` to `crypto-bigint` which provides fixed-but-dynamic precision big integers (`BoxedUint`) which are heap-allocated and can be used in-place of `num_bigint::BigUint`.

Part of this change converts to Montgomery form (`BoxedMontyForm`) in several places where successive modular multiplications or other modular arithmetic is occurring, which should improve efficiency.

The modpow implementation is also shared with `dsa` and `rsa` where we have performed a similar migration from `num-bigint` to `crypto-bigint` in order to address similar issues around constant-time operation and sidechannel leakage.

Closes #191.