### PR TITLE
srp: use `crypto-bigint` v0.7.0-rc.17 crate release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,8 +121,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.16"
-source = "git+https://github.com/RustCrypto/crypto-bigint#b047ab0a78a6542190b47107ef15be108b110a0b"
+version = "0.7.0-rc.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc44c334576a43ddece6194e3bf6f177b402728fde319648e36aaf617a473c7"
 dependencies = [
  "ctutils",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io.crypto-bigint]
-git = "https://github.com/RustCrypto/crypto-bigint"

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-crypto-bigint = { version = "0.7.0-rc.16", features = ["alloc"] }
+crypto-bigint = { version = "0.7.0-rc.17", features = ["alloc"] }
 digest = "0.11.0-rc.5"
 once_cell = "1"
 subtle = "2.4"


### PR DESCRIPTION
Previously we were sourcing it from `git` in order to be able to use `BoxedUint::concatenating_add`