### PR TITLE
srp: remove client and server lifetimes

### DIFF
--- a/srp/src/client.rs
+++ b/srp/src/client.rs
@@ -112,8 +112,8 @@ use crate::{
 };
 
 /// SRP client state before handshake with the server.
-pub struct SrpClient<'a, D: Digest> {
-    params: &'a SrpGroup,
+pub struct SrpClient<D: Digest> {
+    params: &'static SrpGroup,
     no_user_in_x: bool,
     d: PhantomData<D>,
 }
@@ -133,10 +133,10 @@ pub struct SrpClientVerifierRfc5054<D: Digest> {
     session_key: Vec<u8>,
 }
 
-impl<'a, D: Digest> SrpClient<'a, D> {
+impl<D: Digest> SrpClient<D> {
     /// Create new SRP client instance.
     #[must_use]
-    pub const fn new(params: &'a SrpGroup) -> Self {
+    pub const fn new(params: &'static SrpGroup) -> Self {
         Self {
             params,
             no_user_in_x: false,
@@ -145,7 +145,7 @@ impl<'a, D: Digest> SrpClient<'a, D> {
     }
 
     #[must_use]
-    pub const fn new_with_options(params: &'a SrpGroup, no_user_in_x: bool) -> Self {
+    pub const fn new_with_options(params: &'static SrpGroup, no_user_in_x: bool) -> Self {
         Self {
             params,
             no_user_in_x,

--- a/srp/src/server.rs
+++ b/srp/src/server.rs
@@ -90,8 +90,8 @@ use crate::{
 };
 
 /// SRP server state
-pub struct SrpServer<'a, D: Digest> {
-    params: &'a SrpGroup,
+pub struct SrpServer<D: Digest> {
+    params: &'static SrpGroup,
     d: PhantomData<D>,
 }
 
@@ -110,10 +110,10 @@ pub struct SrpServerVerifierRfc5054<D: Digest> {
     session_key: Vec<u8>,
 }
 
-impl<'a, D: Digest> SrpServer<'a, D> {
+impl<D: Digest> SrpServer<D> {
     /// Create new server state.
     #[must_use]
-    pub const fn new(params: &'a SrpGroup) -> Self {
+    pub const fn new(params: &'static SrpGroup) -> Self {
         Self {
             params,
             d: PhantomData,


### PR DESCRIPTION
The only lifetime is a reference to the group, where the groups are all stored in `static`s and therefore we can just use a `'static` lifetime