### PR TITLE
srp: remove `Srp*` prefix from type names

### DIFF
--- a/srp/src/errors.rs
+++ b/srp/src/errors.rs
@@ -5,12 +5,12 @@ use core::{error, fmt};
 
 /// SRP authentication error.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum SrpAuthError {
+pub enum AuthError {
     IllegalParameter(String),
     BadRecordMac(String),
 }
 
-impl fmt::Display for SrpAuthError {
+impl fmt::Display for AuthError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::IllegalParameter(param) => {
@@ -23,4 +23,4 @@ impl fmt::Display for SrpAuthError {
     }
 }
 
-impl error::Error for SrpAuthError {}
+impl error::Error for AuthError {}

--- a/srp/src/groups.rs
+++ b/srp/src/groups.rs
@@ -12,14 +12,14 @@ use once_cell::sync::Lazy;
 
 /// Group used for SRP computations
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct SrpGroup {
+pub struct Group {
     /// A large safe prime (N = 2q+1, where q is prime)
     pub n: BoxedMontyParams,
     /// A generator modulo N
     pub g: BoxedMontyForm,
 }
 
-impl SrpGroup {
+impl Group {
     /// Initialize a new group from the given boxed integers.
     pub fn new(n: BoxedUint, g: BoxedUint) -> Self {
         let n = BoxedMontyParams::new(Odd::new(n).expect("n should be odd"));
@@ -28,36 +28,36 @@ impl SrpGroup {
     }
 }
 
-pub static G_1024: Lazy<SrpGroup> = Lazy::new(|| {
-    SrpGroup::new(
+pub static G_1024: Lazy<Group> = Lazy::new(|| {
+    Group::new(
         BoxedUint::from_be_slice_vartime(include_bytes!("groups/1024.bin")),
         BoxedUint::from_be_slice_vartime(&[2]),
     )
 });
 
-pub static G_1536: Lazy<SrpGroup> = Lazy::new(|| {
-    SrpGroup::new(
+pub static G_1536: Lazy<Group> = Lazy::new(|| {
+    Group::new(
         BoxedUint::from_be_slice_vartime(include_bytes!("groups/1536.bin")),
         BoxedUint::from_be_slice_vartime(&[2]),
     )
 });
 
-pub static G_2048: Lazy<SrpGroup> = Lazy::new(|| {
-    SrpGroup::new(
+pub static G_2048: Lazy<Group> = Lazy::new(|| {
+    Group::new(
         BoxedUint::from_be_slice_vartime(include_bytes!("groups/2048.bin")),
         BoxedUint::from_be_slice_vartime(&[2]),
     )
 });
 
-pub static G_3072: Lazy<SrpGroup> = Lazy::new(|| {
-    SrpGroup::new(
+pub static G_3072: Lazy<Group> = Lazy::new(|| {
+    Group::new(
         BoxedUint::from_be_slice_vartime(include_bytes!("groups/3072.bin")),
         BoxedUint::from_be_slice_vartime(&[5]),
     )
 });
 
-pub static G_4096: Lazy<SrpGroup> = Lazy::new(|| {
-    SrpGroup::new(
+pub static G_4096: Lazy<Group> = Lazy::new(|| {
+    Group::new(
         BoxedUint::from_be_slice_vartime(include_bytes!("groups/4096.bin")),
         BoxedUint::from_be_slice_vartime(&[5]),
     )

--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -63,4 +63,4 @@ pub mod groups;
 pub mod server;
 pub mod utils;
 
-pub use groups::SrpGroup;
+pub use groups::Group;

--- a/srp/src/utils.rs
+++ b/srp/src/utils.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use crypto_bigint::BoxedUint;
 use digest::{Digest, Output};
 
-use crate::groups::SrpGroup;
+use crate::groups::Group;
 
 // u = H(PAD(A) | PAD(B))
 #[must_use]
@@ -15,7 +15,7 @@ pub fn compute_u<D: Digest>(a_pub: &[u8], b_pub: &[u8]) -> BoxedUint {
 
 // k = H(N | PAD(g))
 #[must_use]
-pub fn compute_k<D: Digest>(params: &SrpGroup) -> BoxedUint {
+pub fn compute_k<D: Digest>(params: &Group) -> BoxedUint {
     let n = params.n.modulus().to_be_bytes();
     let g_bytes = params.g.retrieve().to_be_bytes();
     let mut buf = vec![0u8; n.len()];
@@ -30,7 +30,7 @@ pub fn compute_k<D: Digest>(params: &SrpGroup) -> BoxedUint {
 
 // H(N) XOR H(PAD(g))
 #[must_use]
-pub fn compute_hash_n_xor_hash_g<D: Digest>(params: &SrpGroup) -> Vec<u8> {
+pub fn compute_hash_n_xor_hash_g<D: Digest>(params: &Group) -> Vec<u8> {
     let n = params.n.modulus().to_be_bytes();
     let g_bytes = params.g.retrieve().to_be_bytes();
     let mut buf = vec![0u8; n.len()];
@@ -66,7 +66,7 @@ pub fn compute_hash<D: Digest>(data: &[u8]) -> Output<D> {
 // M1 = H(H(N) XOR H(g) | H(U) | s | A | B | K) following RFC5054
 #[must_use]
 pub fn compute_m1_rfc5054<D: Digest>(
-    params: &SrpGroup,
+    params: &Group,
     username: &[u8],
     salt: &[u8],
     a_pub: &[u8],

--- a/srp/tests/bad_public.rs
+++ b/srp/tests/bad_public.rs
@@ -1,13 +1,13 @@
 use crypto_bigint::BoxedUint;
 use sha1::Sha1;
-use srp::client::SrpClient;
+use srp::client::Client;
 use srp::groups::G_1024;
-use srp::server::SrpServer;
+use srp::server::Server;
 
 #[test]
 #[should_panic]
 fn bad_a_pub() {
-    let server = SrpServer::<Sha1>::new(&G_1024);
+    let server = Server::<Sha1>::new(&G_1024);
     server
         .process_reply(b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();
@@ -16,7 +16,7 @@ fn bad_a_pub() {
 #[test]
 #[should_panic]
 fn bad_b_pub() {
-    let client = SrpClient::<Sha1>::new(&G_1024);
+    let client = Client::<Sha1>::new(&G_1024);
     client
         .process_reply(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();

--- a/srp/tests/rfc5054.rs
+++ b/srp/tests/rfc5054.rs
@@ -1,9 +1,9 @@
 use crypto_bigint::BoxedUint;
 use hex_literal::hex;
 use sha1::Sha1;
-use srp::client::SrpClient;
+use srp::client::Client;
 use srp::groups::G_1024;
-use srp::server::SrpServer;
+use srp::server::Server;
 use srp::utils::{compute_k, compute_u};
 
 #[test]
@@ -22,8 +22,8 @@ fn rfc5054() {
         "bad k value"
     );
 
-    let identity_hash = SrpClient::<Sha1>::compute_identity_hash(i, p);
-    let x = SrpClient::<Sha1>::compute_x(identity_hash.as_slice(), &s);
+    let identity_hash = Client::<Sha1>::compute_identity_hash(i, p);
+    let x = Client::<Sha1>::compute_x(identity_hash.as_slice(), &s);
 
     assert_eq!(
         &*x.to_be_bytes_trimmed_vartime(),
@@ -31,7 +31,7 @@ fn rfc5054() {
         "bad x value"
     );
 
-    let client = SrpClient::<Sha1>::new(group);
+    let client = Client::<Sha1>::new(group);
     let v = client.compute_g_x(&x);
 
     assert_eq!(
@@ -70,7 +70,7 @@ fn rfc5054() {
         "bad a_pub value"
     );
 
-    let server = SrpServer::<Sha1>::new(group);
+    let server = Server::<Sha1>::new(group);
     let b_pub = server.compute_b_pub(&b, &k, &v);
 
     assert_eq!(

--- a/srp/tests/srp.rs
+++ b/srp/tests/srp.rs
@@ -3,14 +3,14 @@ use getrandom::{
     rand_core::{RngCore, TryRngCore},
 };
 use sha2::Sha256;
-use srp::{client::SrpClient, groups::G_2048, server::SrpServer};
+use srp::{client::Client, groups::G_2048, server::Server};
 
 fn auth_test(true_pwd: &[u8], auth_pwd: &[u8]) {
     let mut rng = SysRng.unwrap_err();
     let username = b"alice";
 
     // Client instance creation
-    let client = SrpClient::<Sha256>::new(&G_2048);
+    let client = Client::<Sha256>::new(&G_2048);
 
     // Begin Registration
 
@@ -27,7 +27,7 @@ fn auth_test(true_pwd: &[u8], auth_pwd: &[u8]) {
     // User sends username
 
     // Server instance creation
-    let server = SrpServer::<Sha256>::new(&G_2048);
+    let server = Server::<Sha256>::new(&G_2048);
 
     // Server retrieves verifier, salt and computes a public B value
     let mut b = [0u8; 64];
@@ -73,7 +73,7 @@ fn auth_test_rfc5054(true_pwd: &[u8], auth_pwd: &[u8]) {
     let username = b"alice";
 
     // Client instance creation
-    let client = SrpClient::<Sha256>::new(&G_2048);
+    let client = Client::<Sha256>::new(&G_2048);
 
     // Begin Registration
 
@@ -90,7 +90,7 @@ fn auth_test_rfc5054(true_pwd: &[u8], auth_pwd: &[u8]) {
     // User sends username
 
     // Server instance creation
-    let server = SrpServer::<Sha256>::new(&G_2048);
+    let server = Server::<Sha256>::new(&G_2048);
 
     // Server retrieves verifier, salt and computes a public B value
     let mut b = [0u8; 64];


### PR DESCRIPTION
This follows RFC 356 which suggests that type names should not include redundant prefixes:

https://rust-lang.github.io/rfcs/0356-no-module-prefixes.html