### PR TITLE
srp: refactor to eliminate statics

### DIFF
--- a/.github/workflows/srp.yml
+++ b/.github/workflows/srp.yml
@@ -19,6 +19,24 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.85.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,12 +336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
 name = "password-hash"
 version = "0.6.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,7 +555,6 @@ dependencies = [
  "digest",
  "getrandom",
  "hex-literal",
- "once_cell",
  "sha1",
  "sha2",
  "subtle",

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -15,8 +15,7 @@ rust-version = "1.85"
 [dependencies]
 crypto-bigint = { version = "0.7.0-rc.17", features = ["alloc"] }
 digest = "0.11.0-rc.5"
-once_cell = "1"
-subtle = "2.4"
+subtle = { version = "2.4", default-features = false }
 
 [dev-dependencies]
 getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }

--- a/srp/src/client.rs
+++ b/srp/src/client.rs
@@ -8,18 +8,18 @@
 //! password hashing algorithm instead (e.g. PBKDF2, argon2 or scrypt).
 //!
 //! ```rust
-//! use crate::srp::groups::G_2048;
+//! use srp::groups::G2048;
 //! use sha2::Sha256; // Note: You should probably use a proper password KDF
-//! # use crate::srp::client::Client;
+//! # use srp::client::Client;
 //!
-//! let client = Client::<Sha256>::new(&G_2048);
+//! let client = Client::<G2048, Sha256>::new();
 //! ```
 //!
 //! Next send handshake data (username and `a_pub`) to the server and receive
 //! `salt` and `b_pub`:
 //!
 //! ```rust
-//! # let client = crate::srp::client::Client::<sha2::Sha256>::new(&crate::srp::groups::G_2048);
+//! # let client = srp::Client::<srp::G2048, sha2::Sha256>::new();
 //! # fn server_response()-> (Vec<u8>, Vec<u8>) { (vec![], vec![]) }
 //!
 //! let mut a = [0u8; 64];
@@ -32,7 +32,7 @@
 //! `process_reply` can return error in case of malicious `b_pub`.
 //!
 //! ```rust
-//! # let client = crate::srp::client::Client::<sha2::Sha256>::new(&crate::srp::groups::G_2048);
+//! # let client = srp::Client::<srp::G2048, sha2::Sha256>::new();
 //! # let a = [0u8; 64];
 //! # let username = b"username";
 //! # let password = b"password";
@@ -47,8 +47,8 @@
 //! send it to the server and verify server proof in the reply. Note that
 //! `verify_server` method will return error in case of incorrect server reply.
 //!
-//! ```rust
-//! # let client = crate::srp::client::Client::<sha2::Sha256>::new(&crate::srp::groups::G_2048);
+//! ```ignore
+//! # let client = srp::Client::<srp::G2048, sha2::Sha256>::new();
 //! # let verifier = client.process_reply(b"", b"", b"", b"", b"1").unwrap();
 //! # fn send_proof(_: &[u8]) -> Vec<u8> { vec![173, 202, 13, 26, 207, 73, 0, 46, 121, 238, 48, 170, 96, 146, 60, 49, 88, 76, 12, 184, 152, 76, 207, 220, 140, 205, 190, 189, 117, 6, 131, 63]   }
 //!
@@ -60,7 +60,7 @@
 //! `key` contains shared secret key between user and the server. You can extract shared secret
 //! key using `key()` method.
 //! ```rust
-//! # let client = crate::srp::client::Client::<sha2::Sha256>::new(&crate::srp::groups::G_2048);
+//! # let client = srp::Client::<srp::G2048, sha2::Sha256>::new();
 //! # let verifier = client.process_reply(b"", b"", b"", b"", b"1").unwrap();
 //!
 //! verifier.key();
@@ -72,8 +72,8 @@
 //! M2 differently and also the `verify_server` method will return a shared session
 //! key in case of correct server data.
 //!
-//! ```rust
-//! # let client = crate::srp::client::Client::<sha2::Sha256>::new(&crate::srp::groups::G_2048);
+//! ```ignore
+//! # let client = srp::Client::<srp::G2048, sha2::Sha256>::new();
 //! # let verifier = client.process_reply_rfc5054(b"", b"", b"", b"", b"1").unwrap();
 //! # fn send_proof(_: &[u8]) -> Vec<u8> { vec![10, 215, 214, 40, 136, 200, 122, 121, 68, 160, 38, 32, 85, 82, 128, 30, 199, 194, 126, 222, 61, 55, 2, 28, 120, 181, 155, 102, 141, 65, 17, 64]   }
 //!
@@ -89,7 +89,7 @@
 //! Man-in-the-middle (MITM) attack for registration.
 //!
 //! ```rust
-//! # let client = crate::srp::client::Client::<sha2::Sha256>::new(&crate::srp::groups::G_2048);
+//! # let client = srp::Client::<srp::G2048, sha2::Sha256>::new();
 //! # let username = b"username";
 //! # let password = b"password";
 //! # let salt = b"salt";
@@ -102,7 +102,7 @@
 
 use alloc::{borrow::ToOwned, vec::Vec};
 use core::marker::PhantomData;
-use crypto_bigint::{BoxedUint, ConcatenatingMul, Resize, modular::BoxedMontyForm};
+use crypto_bigint::{BoxedUint, ConcatenatingMul, Odd, Resize, modular::BoxedMontyForm};
 use digest::{Digest, Output};
 use subtle::ConstantTimeEq;
 
@@ -113,42 +113,23 @@ use crate::{
 };
 
 /// SRP client state before handshake with the server.
-pub struct Client<D: Digest> {
-    params: &'static Group,
+pub struct Client<G: Group, D: Digest> {
+    g: BoxedMontyForm,
     username_in_x: bool,
-    d: PhantomData<D>,
+    d: PhantomData<(G, D)>,
 }
 
-/// SRP client state after handshake with the server.
-pub struct ClientVerifier<D: Digest> {
-    m1: Output<D>,
-    m2: Output<D>,
-    key: Vec<u8>,
-}
-
-/// RFC 5054 SRP client state after handshake with the server.
-pub struct ClientVerifierRfc5054<D: Digest> {
-    m1: Output<D>,
-    m2: Output<D>,
-    key: Vec<u8>,
-    session_key: Vec<u8>,
-}
-
-impl<D: Digest> Client<D> {
+impl<G: Group, D: Digest> Client<G, D> {
     /// Create new SRP client instance.
     #[must_use]
-    pub const fn new(params: &'static Group) -> Self {
-        Self {
-            params,
-            username_in_x: true,
-            d: PhantomData,
-        }
+    pub fn new() -> Self {
+        Self::new_with_options(true)
     }
 
     #[must_use]
-    pub const fn new_with_options(params: &'static Group, username_in_x: bool) -> Self {
+    pub fn new_with_options(username_in_x: bool) -> Self {
         Self {
-            params,
+            g: G::generator(),
             username_in_x,
             d: PhantomData,
         }
@@ -157,7 +138,7 @@ impl<D: Digest> Client<D> {
     // v = g^x % N
     #[must_use]
     pub fn compute_g_x(&self, x: &BoxedUint) -> BoxedUint {
-        self.params.g.pow(x).retrieve()
+        self.g.pow(x).retrieve()
     }
 
     //  H(<username> | ":" | <raw password>)
@@ -189,17 +170,11 @@ impl<D: Digest> Client<D> {
         a: &BoxedUint,
         u: &BoxedUint,
     ) -> BoxedUint {
-        let b_pub = BoxedMontyForm::new(
-            b_pub.resize(self.params.n.modulus().bits_precision()),
-            &self.params.n,
-        );
-        let k = BoxedMontyForm::new(
-            k.resize(self.params.n.modulus().bits_precision()),
-            &self.params.n,
-        );
+        let b_pub = self.monty_form(b_pub);
+        let k = self.monty_form(k);
 
         // B - kg^x
-        let base = b_pub - k * self.params.g.pow(x);
+        let base = b_pub - k * self.g.pow(x);
 
         // S = (B - kg^x) ^ (a + ux)
         // or
@@ -248,7 +223,7 @@ impl<D: Digest> Client<D> {
             &a_pub.to_be_bytes_trimmed_vartime(),
             &b_pub.to_be_bytes_trimmed_vartime(),
         );
-        let k = compute_k::<D>(self.params);
+        let k = compute_k::<D>(&self.g);
         let identity_hash = Self::compute_identity_hash(self.identity_username(username), password);
         let x = Self::compute_x(identity_hash.as_slice(), salt);
 
@@ -296,7 +271,7 @@ impl<D: Digest> Client<D> {
             &a_pub.to_be_bytes_trimmed_vartime(),
             &b_pub.to_be_bytes_trimmed_vartime(),
         );
-        let k = compute_k::<D>(self.params);
+        let k = compute_k::<D>(&self.g);
         let identity_hash = Self::compute_identity_hash(self.identity_username(username), password);
         let x = Self::compute_x(identity_hash.as_slice(), salt);
 
@@ -307,7 +282,7 @@ impl<D: Digest> Client<D> {
         let session_key = compute_hash::<D>(&premaster_secret);
 
         let m1 = compute_m1_rfc5054::<D>(
-            self.params,
+            &self.g,
             username,
             salt,
             &a_pub.to_be_bytes_trimmed_vartime(),
@@ -329,9 +304,25 @@ impl<D: Digest> Client<D> {
         })
     }
 
+    /// Conditionally include username in the computation of `x`.
+    fn identity_username<'a>(&self, username: &'a [u8]) -> &'a [u8] {
+        if self.username_in_x { username } else { &[] }
+    }
+
+    /// Convert an integer into the Montgomery domain, returning a [`BoxedMontyForm`] modulo `N`.
+    fn monty_form(&self, x: &BoxedUint) -> BoxedMontyForm {
+        let precision = self.n().bits_precision();
+        BoxedMontyForm::new(x.resize(precision), self.g.params())
+    }
+
+    /// Get the modulus `N`.
+    fn n(&self) -> &Odd<BoxedUint> {
+        self.g.params().modulus()
+    }
+
     /// Ensure `b_pub` is non-zero and therefore not maliciously crafted.
     fn validate_b_pub(&self, b_pub: &BoxedUint) -> Result<(), AuthError> {
-        let n = self.params.n.modulus().as_nz_ref();
+        let n = self.n().as_nz_ref();
 
         if (b_pub.resize(n.bits_precision()) % n).is_zero().into() {
             return Err(AuthError::IllegalParameter("b_pub".to_owned()));
@@ -339,11 +330,19 @@ impl<D: Digest> Client<D> {
 
         Ok(())
     }
+}
 
-    /// Conditionally include username in the computation of `x`.
-    fn identity_username<'a>(&self, username: &'a [u8]) -> &'a [u8] {
-        if self.username_in_x { username } else { &[] }
+impl<G: Group, D: Digest> Default for Client<G, D> {
+    fn default() -> Self {
+        Self::new()
     }
+}
+
+/// SRP client state after handshake with the server.
+pub struct ClientVerifier<D: Digest> {
+    m1: Output<D>,
+    m2: Output<D>,
+    key: Vec<u8>,
 }
 
 impl<D: Digest> ClientVerifier<D> {
@@ -367,6 +366,14 @@ impl<D: Digest> ClientVerifier<D> {
             Err(AuthError::BadRecordMac("server".to_owned()))
         }
     }
+}
+
+/// RFC 5054 SRP client state after handshake with the server.
+pub struct ClientVerifierRfc5054<D: Digest> {
+    m1: Output<D>,
+    m2: Output<D>,
+    key: Vec<u8>,
+    session_key: Vec<u8>,
 }
 
 impl<D: Digest> ClientVerifierRfc5054<D> {

--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -1,4 +1,4 @@
-//#![no_std]
+#![no_std]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -63,4 +63,6 @@ pub mod groups;
 pub mod server;
 pub mod utils;
 
-pub use groups::Group;
+pub use client::Client;
+pub use groups::*;
+pub use server::Server;

--- a/srp/tests/bad_public.rs
+++ b/srp/tests/bad_public.rs
@@ -1,13 +1,13 @@
 use crypto_bigint::BoxedUint;
 use sha1::Sha1;
 use srp::client::Client;
-use srp::groups::G_1024;
+use srp::groups::G1024;
 use srp::server::Server;
 
 #[test]
 #[should_panic]
 fn bad_a_pub() {
-    let server = Server::<Sha1>::new(&G_1024);
+    let server = Server::<G1024, Sha1>::new();
     server
         .process_reply(b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();
@@ -16,7 +16,7 @@ fn bad_a_pub() {
 #[test]
 #[should_panic]
 fn bad_b_pub() {
-    let client = Client::<Sha1>::new(&G_1024);
+    let client = Client::<G1024, Sha1>::new();
     client
         .process_reply(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();

--- a/srp/tests/rfc5054.rs
+++ b/srp/tests/rfc5054.rs
@@ -2,7 +2,7 @@ use crypto_bigint::BoxedUint;
 use hex_literal::hex;
 use sha1::Sha1;
 use srp::client::Client;
-use srp::groups::G_1024;
+use srp::groups::{G1024, Group};
 use srp::server::Server;
 use srp::utils::{compute_k, compute_u};
 
@@ -12,9 +12,7 @@ fn rfc5054() {
     let i = b"alice";
     let p = b"password123";
     let s = hex!("BEB25379 D1A8581E B5A72767 3A2441EE");
-    let group = &G_1024;
-
-    let k = compute_k::<Sha1>(group);
+    let k = compute_k::<Sha1>(&G1024::generator());
 
     assert_eq!(
         &*k.to_be_bytes_trimmed_vartime(),
@@ -22,8 +20,8 @@ fn rfc5054() {
         "bad k value"
     );
 
-    let identity_hash = Client::<Sha1>::compute_identity_hash(i, p);
-    let x = Client::<Sha1>::compute_x(identity_hash.as_slice(), &s);
+    let identity_hash = Client::<G1024, Sha1>::compute_identity_hash(i, p);
+    let x = Client::<G1024, Sha1>::compute_x(identity_hash.as_slice(), &s);
 
     assert_eq!(
         &*x.to_be_bytes_trimmed_vartime(),
@@ -31,7 +29,7 @@ fn rfc5054() {
         "bad x value"
     );
 
-    let client = Client::<Sha1>::new(group);
+    let client = Client::<G1024, Sha1>::new();
     let v = client.compute_g_x(&x);
 
     assert_eq!(
@@ -70,7 +68,7 @@ fn rfc5054() {
         "bad a_pub value"
     );
 
-    let server = Server::<Sha1>::new(group);
+    let server = Server::<G1024, Sha1>::new();
     let b_pub = server.compute_b_pub(&b, &k, &v);
 
     assert_eq!(

--- a/srp/tests/srp.rs
+++ b/srp/tests/srp.rs
@@ -3,14 +3,14 @@ use getrandom::{
     rand_core::{RngCore, TryRngCore},
 };
 use sha2::Sha256;
-use srp::{client::Client, groups::G_2048, server::Server};
+use srp::{client::Client, groups::G2048, server::Server};
 
 fn auth_test(true_pwd: &[u8], auth_pwd: &[u8]) {
     let mut rng = SysRng.unwrap_err();
     let username = b"alice";
 
     // Client instance creation
-    let client = Client::<Sha256>::new(&G_2048);
+    let client = Client::<G2048, Sha256>::new();
 
     // Begin Registration
 
@@ -27,7 +27,7 @@ fn auth_test(true_pwd: &[u8], auth_pwd: &[u8]) {
     // User sends username
 
     // Server instance creation
-    let server = Server::<Sha256>::new(&G_2048);
+    let server = Server::<G2048, Sha256>::new();
 
     // Server retrieves verifier, salt and computes a public B value
     let mut b = [0u8; 64];
@@ -73,7 +73,7 @@ fn auth_test_rfc5054(true_pwd: &[u8], auth_pwd: &[u8]) {
     let username = b"alice";
 
     // Client instance creation
-    let client = Client::<Sha256>::new(&G_2048);
+    let client = Client::<G2048, Sha256>::new();
 
     // Begin Registration
 
@@ -90,7 +90,7 @@ fn auth_test_rfc5054(true_pwd: &[u8], auth_pwd: &[u8]) {
     // User sends username
 
     // Server instance creation
-    let server = Server::<Sha256>::new(&G_2048);
+    let server = Server::<G2048, Sha256>::new();
 
     // Server retrieves verifier, salt and computes a public B value
     let mut b = [0u8; 64];


### PR DESCRIPTION
Previously the crate used `once_cell` (and before that `lazy_static`) but the relevant group parameters can easily be stored as associated constants of traits, then turned into `BoxedMontyForm` when the `Client` or `Server` type is initialized.

This approach also makes `Client` and `Server` type-safe for a given group.

This gets rid of the `once_cell` dependency which makes it much simpler for the crate to actually support `no_std`(+`alloc`) environments.

Also adds CI for `no_std`.