### PR TITLE
srp: eliminate allocations in `AuthError`

### DIFF
--- a/srp/src/client.rs
+++ b/srp/src/client.rs
@@ -100,7 +100,7 @@
 //! ```
 //!
 
-use alloc::{borrow::ToOwned, vec::Vec};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use crypto_bigint::{BoxedUint, ConcatenatingMul, Odd, Resize, modular::BoxedMontyForm};
 use digest::{Digest, Output};
@@ -325,7 +325,7 @@ impl<G: Group, D: Digest> Client<G, D> {
         let n = self.n().as_nz_ref();
 
         if (b_pub.resize(n.bits_precision()) % n).is_zero().into() {
-            return Err(AuthError::IllegalParameter("b_pub".to_owned()));
+            return Err(AuthError::IllegalParameter { name: "b_pub" });
         }
 
         Ok(())
@@ -363,7 +363,7 @@ impl<D: Digest> ClientVerifier<D> {
         if self.m2.ct_eq(reply).unwrap_u8() == 1 {
             Ok(())
         } else {
-            Err(AuthError::BadRecordMac("server".to_owned()))
+            Err(AuthError::BadRecordMac { peer: "server" })
         }
     }
 }
@@ -394,7 +394,7 @@ impl<D: Digest> ClientVerifierRfc5054<D> {
         if self.m2.ct_eq(reply).unwrap_u8() == 1 {
             Ok(self.session_key.as_slice())
         } else {
-            Err(AuthError::BadRecordMac("server".to_owned()))
+            Err(AuthError::BadRecordMac { peer: "server" })
         }
     }
 }

--- a/srp/src/errors.rs
+++ b/srp/src/errors.rs
@@ -1,23 +1,28 @@
 //! Error types.
 
-use alloc::string::String;
 use core::{error, fmt};
 
 /// SRP authentication error.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum AuthError {
-    IllegalParameter(String),
-    BadRecordMac(String),
+    IllegalParameter {
+        /// Parameter name
+        name: &'static str,
+    },
+    BadRecordMac {
+        /// Which peer's proof is invalid
+        peer: &'static str,
+    },
 }
 
 impl fmt::Display for AuthError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::IllegalParameter(param) => {
-                write!(f, "illegal_parameter: bad '{param}' value")
+            Self::IllegalParameter { name } => {
+                write!(f, "illegal_parameter: bad '{name}' value")
             }
-            Self::BadRecordMac(param) => {
-                write!(f, "bad_record_mac: incorrect '{param}'  proof")
+            Self::BadRecordMac { peer } => {
+                write!(f, "bad_record_mac: incorrect '{peer}' proof")
             }
         }
     }

--- a/srp/src/server.rs
+++ b/srp/src/server.rs
@@ -77,7 +77,7 @@
 //! send_proof(verifier.proof());
 //! ```
 //!
-use alloc::{borrow::ToOwned, vec::Vec};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use crypto_bigint::{BoxedUint, Odd, Resize, modular::BoxedMontyForm};
@@ -258,7 +258,7 @@ impl<G: Group, D: Digest> Server<G, D> {
         let n = self.n().as_nz_ref();
 
         if (a_pub.resize(n.bits_precision()) % n).is_zero().into() {
-            return Err(AuthError::IllegalParameter("a_pub".to_owned()));
+            return Err(AuthError::IllegalParameter { name: "a_pub" });
         }
 
         Ok(())
@@ -296,7 +296,7 @@ impl<D: Digest> ServerVerifier<D> {
         if self.m1.ct_eq(reply).unwrap_u8() == 1 {
             Ok(())
         } else {
-            Err(AuthError::BadRecordMac("client".to_owned()))
+            Err(AuthError::BadRecordMac { peer: "client" })
         }
     }
 }
@@ -327,7 +327,7 @@ impl<D: Digest> ServerVerifierRfc5054<D> {
         if self.m1.ct_eq(reply).unwrap_u8() == 1 {
             Ok(self.session_key.as_slice())
         } else {
-            Err(AuthError::BadRecordMac("client".to_owned()))
+            Err(AuthError::BadRecordMac { peer: "client" })
         }
     }
 }


### PR DESCRIPTION
We can easily use `&'static str` instead