### PR TITLE
srp: rename and deprecate legacy implementation

### DIFF
--- a/srp/tests/bad_public.rs
+++ b/srp/tests/bad_public.rs
@@ -9,7 +9,7 @@ use srp::server::Server;
 fn bad_a_pub() {
     let server = Server::<G1024, Sha1>::new();
     server
-        .process_reply(b"", b"", &BoxedUint::zero().to_be_bytes())
+        .process_reply_rfc5054(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();
 }
 
@@ -18,6 +18,6 @@ fn bad_a_pub() {
 fn bad_b_pub() {
     let client = Client::<G1024, Sha1>::new();
     client
-        .process_reply(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
+        .process_reply_rfc5054(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();
 }

--- a/srp/tests/srp.rs
+++ b/srp/tests/srp.rs
@@ -5,69 +5,6 @@ use getrandom::{
 use sha2::Sha256;
 use srp::{client::Client, groups::G2048, server::Server};
 
-fn auth_test(true_pwd: &[u8], auth_pwd: &[u8]) {
-    let mut rng = SysRng.unwrap_err();
-    let username = b"alice";
-
-    // Client instance creation
-    let client = Client::<G2048, Sha256>::new();
-
-    // Begin Registration
-
-    let mut salt = [0u8; 16];
-    rng.fill_bytes(&mut salt);
-    let verifier = client.compute_verifier(username, true_pwd, &salt);
-
-    // Client sends username and verifier and salt to the Server for storage
-
-    // Registration Ends
-
-    // Begin Authentication
-
-    // User sends username
-
-    // Server instance creation
-    let server = Server::<G2048, Sha256>::new();
-
-    // Server retrieves verifier, salt and computes a public B value
-    let mut b = [0u8; 64];
-    rng.fill_bytes(&mut b);
-    let (salt, b_pub) = (&salt, server.compute_public_ephemeral(&b, &verifier));
-
-    // Server sends salt and b_pub to client
-
-    // Client computes the public A value and the clientVerifier containing the key, m1, and m2
-    let mut a = [0u8; 64];
-    rng.fill_bytes(&mut a);
-    let client_verifier = client
-        .process_reply(&a, username, auth_pwd, salt, &b_pub)
-        .unwrap();
-    let a_pub = client.compute_public_ephemeral(&a);
-    let client_proof = client_verifier.proof();
-
-    // Client sends a_pub and client_proof to server (M1)
-
-    // Server processes verification data
-    let server_verifier = server.process_reply(&b, &verifier, &a_pub).unwrap();
-    println!("Client verification on server");
-    server_verifier.verify_client(client_proof).unwrap();
-    let server_proof = server_verifier.proof();
-    let server_key = server_verifier.key();
-
-    // Server sends server_proof to client (M2)
-
-    // Client verifies server
-    println!("Server verification on client");
-    client_verifier.verify_server(server_proof).unwrap();
-    let client_key = client_verifier.key();
-
-    // our keys also must be equal, but just an extra check to be sure
-    assert_eq!(
-        server_key, client_key,
-        "server and client keys are not equal"
-    );
-}
-
 fn auth_test_rfc5054(true_pwd: &[u8], auth_pwd: &[u8]) {
     let mut rng = SysRng.unwrap_err();
     let username = b"alice";
@@ -139,15 +76,68 @@ fn auth_test_rfc5054(true_pwd: &[u8], auth_pwd: &[u8]) {
     );
 }
 
-#[test]
-fn good_password() {
-    auth_test(b"password", b"password");
-}
+#[allow(deprecated)]
+fn auth_test_legacy(true_pwd: &[u8], auth_pwd: &[u8]) {
+    let mut rng = SysRng.unwrap_err();
+    let username = b"alice";
 
-#[test]
-#[should_panic]
-fn bad_password() {
-    auth_test(b"password", b"paSsword");
+    // Client instance creation
+    let client = Client::<G2048, Sha256>::new();
+
+    // Begin Registration
+
+    let mut salt = [0u8; 16];
+    rng.fill_bytes(&mut salt);
+    let verifier = client.compute_verifier(username, true_pwd, &salt);
+
+    // Client sends username and verifier and salt to the Server for storage
+
+    // Registration Ends
+
+    // Begin Authentication
+
+    // User sends username
+
+    // Server instance creation
+    let server = Server::<G2048, Sha256>::new();
+
+    // Server retrieves verifier, salt and computes a public B value
+    let mut b = [0u8; 64];
+    rng.fill_bytes(&mut b);
+    let (salt, b_pub) = (&salt, server.compute_public_ephemeral(&b, &verifier));
+
+    // Server sends salt and b_pub to client
+
+    // Client computes the public A value and the clientVerifier containing the key, m1, and m2
+    let mut a = [0u8; 64];
+    rng.fill_bytes(&mut a);
+    let client_verifier = client
+        .process_reply_legacy(&a, username, auth_pwd, salt, &b_pub)
+        .unwrap();
+    let a_pub = client.compute_public_ephemeral(&a);
+    let client_proof = client_verifier.proof();
+
+    // Client sends a_pub and client_proof to server (M1)
+
+    // Server processes verification data
+    let server_verifier = server.process_reply_legacy(&b, &verifier, &a_pub).unwrap();
+    println!("Client verification on server");
+    server_verifier.verify_client(client_proof).unwrap();
+    let server_proof = server_verifier.proof();
+    let server_key = server_verifier.key();
+
+    // Server sends server_proof to client (M2)
+
+    // Client verifies server
+    println!("Server verification on client");
+    client_verifier.verify_server(server_proof).unwrap();
+    let client_key = client_verifier.key();
+
+    // our keys also must be equal, but just an extra check to be sure
+    assert_eq!(
+        server_key, client_key,
+        "server and client keys are not equal"
+    );
 }
 
 #[test]
@@ -159,4 +149,15 @@ fn rfc5054_good_password() {
 #[should_panic]
 fn rfc5054_bad_password() {
     auth_test_rfc5054(b"password", b"paSsword");
+}
+
+#[test]
+fn legacy_good_password() {
+    auth_test_legacy(b"password", b"password");
+}
+
+#[test]
+#[should_panic]
+fn legacy_bad_password() {
+    auth_test_legacy(b"password", b"paSsword");
 }


### PR DESCRIPTION
Attempts to steer people towards the new RFC5054-compatible implementation by adding `*_legacy` and `Legacy*` to methods and types for the `srp` v0.6-and-earlier compatible implementation.

Ideally it can be removed in the next breaking release after this one, and we can only support RFC5054. But for now, this makes a migration possible.