### PR TITLE
srp: make RFC5054 the default implementation

### DIFF
--- a/srp/src/client.rs
+++ b/srp/src/client.rs
@@ -203,17 +203,17 @@ impl<G: Group, D: Digest> Client<G, D> {
     /// Process server reply to the handshake according to RFC 5054.
     ///
     /// # Params
-    /// `a` is a random value,
-    /// `username`, `password` is supplied by the user
-    /// `salt` and `b_pub` come from the server
-    pub fn process_reply_rfc5054(
+    /// - `a` is a random value,
+    /// - `username`, `password` is supplied by the user
+    /// - `salt` and `b_pub` come from the server
+    pub fn process_reply(
         &self,
         a: &[u8],
         username: &[u8],
         password: &[u8],
         salt: &[u8],
         b_pub: &[u8],
-    ) -> Result<ClientVerifierRfc5054<D>, AuthError> {
+    ) -> Result<ClientVerifier<D>, AuthError> {
         let a = BoxedUint::from_be_slice_vartime(a);
         let a_pub = self.compute_g_x(&a);
         let b_pub = BoxedUint::from_be_slice_vartime(b_pub);
@@ -250,7 +250,7 @@ impl<G: Group, D: Digest> Client<G, D> {
             session_key.as_slice(),
         );
 
-        Ok(ClientVerifierRfc5054 {
+        Ok(ClientVerifier {
             m1,
             m2,
             key: premaster_secret.to_vec(),
@@ -351,14 +351,14 @@ impl<G: Group, D: Digest> Default for Client<G, D> {
 }
 
 /// RFC 5054 SRP client state after handshake with the server.
-pub struct ClientVerifierRfc5054<D: Digest> {
+pub struct ClientVerifier<D: Digest> {
     m1: Output<D>,
     m2: Output<D>,
     key: Vec<u8>,
     session_key: Vec<u8>,
 }
 
-impl<D: Digest> ClientVerifierRfc5054<D> {
+impl<D: Digest> ClientVerifier<D> {
     /// Get shared secret key without authenticating server, e.g. for using with
     /// authenticated encryption modes. DO NOT USE this method without
     /// some kind of secure authentication

--- a/srp/src/server.rs
+++ b/srp/src/server.rs
@@ -147,14 +147,14 @@ impl<G: Group, D: Digest> Server<G, D> {
     /// # Params
     /// - `b` is a random value,
     /// - `v` is the provided during initial user registration
-    pub fn process_reply_rfc5054(
+    pub fn process_reply(
         &self,
         username: &[u8],
         salt: &[u8],
         b: &[u8],
         v: &[u8],
         a_pub: &[u8],
-    ) -> Result<ServerVerifierRfc5054<D>, AuthError> {
+    ) -> Result<ServerVerifier<D>, AuthError> {
         let b = BoxedUint::from_be_slice_vartime(b);
         let v = BoxedUint::from_be_slice_vartime(v);
         let a_pub = BoxedUint::from_be_slice_vartime(a_pub);
@@ -191,7 +191,7 @@ impl<G: Group, D: Digest> Server<G, D> {
             session_key.as_slice(),
         );
 
-        Ok(ServerVerifierRfc5054 {
+        Ok(ServerVerifier {
             m1,
             m2,
             key: premaster_secret.into(),
@@ -284,14 +284,14 @@ impl<G: Group, D: Digest> Default for Server<G, D> {
 }
 
 /// RFC 5054 SRP server state after handshake with the client.
-pub struct ServerVerifierRfc5054<D: Digest> {
+pub struct ServerVerifier<D: Digest> {
     m1: Output<D>,
     m2: Output<D>,
     key: Vec<u8>,
     session_key: Vec<u8>,
 }
 
-impl<D: Digest> ServerVerifierRfc5054<D> {
+impl<D: Digest> ServerVerifier<D> {
     /// Get shared secret between user and the server. (do not forget to verify
     /// that keys are the same!)
     pub fn key(&self) -> &[u8] {

--- a/srp/tests/bad_public.rs
+++ b/srp/tests/bad_public.rs
@@ -9,7 +9,7 @@ use srp::server::Server;
 fn bad_a_pub() {
     let server = Server::<G1024, Sha1>::new();
     server
-        .process_reply_rfc5054(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
+        .process_reply(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();
 }
 
@@ -18,6 +18,6 @@ fn bad_a_pub() {
 fn bad_b_pub() {
     let client = Client::<G1024, Sha1>::new();
     client
-        .process_reply_rfc5054(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
+        .process_reply(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();
 }

--- a/srp/tests/srp.rs
+++ b/srp/tests/srp.rs
@@ -40,7 +40,7 @@ fn auth_test_rfc5054(true_pwd: &[u8], auth_pwd: &[u8]) {
     let mut a = [0u8; 64];
     rng.fill_bytes(&mut a);
     let client_verifier = client
-        .process_reply_rfc5054(&a, username, auth_pwd, salt, &b_pub)
+        .process_reply(&a, username, auth_pwd, salt, &b_pub)
         .unwrap();
     let a_pub = client.compute_public_ephemeral(&a);
     let client_proof = client_verifier.proof();
@@ -49,7 +49,7 @@ fn auth_test_rfc5054(true_pwd: &[u8], auth_pwd: &[u8]) {
 
     // Server processes verification data
     let server_verifier = server
-        .process_reply_rfc5054(username, salt, &b, &verifier, &a_pub)
+        .process_reply(username, salt, &b, &verifier, &a_pub)
         .unwrap();
     println!("Client verification on server");
     let server_session_key = server_verifier.verify_client(client_proof).unwrap();


### PR DESCRIPTION
Removes `*_rfc5054` and `*Rfc5054` from method and type names so the RFC5054 methods/types seem like the primary ones to use.