### PR TITLE
srp: flatten API

### DIFF
--- a/srp/src/groups.rs
+++ b/srp/src/groups.rs
@@ -38,11 +38,11 @@ macro_rules! define_group {
     };
 }
 
-define_group!(G1024, 2, "groups/1024.bin", "1024-bit group");
-define_group!(G1536, 2, "groups/1536.bin", "1536-bit group");
-define_group!(G2048, 2, "groups/2048.bin", "2048-bit group");
-define_group!(G3072, 5, "groups/3072.bin", "3072-bit group");
-define_group!(G4096, 5, "groups/4096.bin", "4096-bit group");
+define_group!(G1024, 2, "groups/1024.bin", "1024-bit group.");
+define_group!(G1536, 2, "groups/1536.bin", "1536-bit group.");
+define_group!(G2048, 2, "groups/2048.bin", "2048-bit group.");
+define_group!(G3072, 5, "groups/3072.bin", "3072-bit group.");
+define_group!(G4096, 5, "groups/4096.bin", "4096-bit group.");
 
 #[cfg(test)]
 mod tests {

--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -7,22 +7,15 @@
 #![allow(clippy::many_single_char_names)]
 
 //! # Usage
-//! Add `srp` dependency to your `Cargo.toml`:
-//!
-//! ```toml
-//! [dependencies]
-//! srp = "0.6"
-//! ```
-//!
-//! Next read documentation for [`client`](client/index.html) and
-//! [`server`](server/index.html) modules.
+//! See [`Client`] and [`Server`] types for usage information.
 //!
 //! # Algorithm description
-//! Here we briefly describe implemented algorithm. For additional information
-//! refer to SRP literature. All arithmetic is done modulo `N`, where `N` is a
-//! large safe prime (`N = 2q+1`, where `q` is prime). Additionally `g` MUST be
-//! a generator modulo `N`. It's STRONGLY recommended to use SRP parameters
-//! provided by this crate in the [`groups`](groups/index.html) module.
+//! Here we briefly describe implemented algorithm. For additional information refer to SRP
+//! literature. All arithmetic is done modulo `N`, where `N` is a large safe prime
+//! (`N = 2q + 1`, where `q` is prime).
+//!
+//! Additionally, `g` MUST be a generator modulo `N`. It's STRONGLY recommended to use SRP
+//! parameters provided by this crate as [`G1024`], [`G1536`], [`G2048`], [`G3072`] and [`G4096`].
 //!
 //! |       Client           |   Data transfer   |      Server                     |
 //! |------------------------|-------------------|---------------------------------|
@@ -57,12 +50,17 @@
 #[macro_use]
 extern crate alloc;
 
-pub mod client;
-pub mod errors;
-pub mod groups;
-pub mod server;
+mod client;
+mod errors;
+mod groups;
+mod server;
+#[doc(hidden)]
 pub mod utils;
 
-pub use client::Client;
+pub use client::{Client, ClientVerifier};
+pub use errors::AuthError;
 pub use groups::*;
-pub use server::Server;
+pub use server::{Server, ServerVerifier};
+
+#[allow(deprecated)]
+pub use {client::LegacyClientVerifier, server::LegacyServerVerifier};

--- a/srp/tests/bad_public.rs
+++ b/srp/tests/bad_public.rs
@@ -1,8 +1,6 @@
 use crypto_bigint::BoxedUint;
 use sha1::Sha1;
-use srp::client::Client;
-use srp::groups::G1024;
-use srp::server::Server;
+use srp::{Client, G1024, Server};
 
 #[test]
 #[should_panic]

--- a/srp/tests/rfc5054.rs
+++ b/srp/tests/rfc5054.rs
@@ -1,10 +1,8 @@
 use crypto_bigint::BoxedUint;
 use hex_literal::hex;
 use sha1::Sha1;
-use srp::client::Client;
-use srp::groups::{G1024, Group};
-use srp::server::Server;
 use srp::utils::{compute_k, compute_u};
+use srp::{Client, G1024, Group, Server};
 
 #[test]
 #[allow(clippy::many_single_char_names)]

--- a/srp/tests/srp.rs
+++ b/srp/tests/srp.rs
@@ -3,7 +3,7 @@ use getrandom::{
     rand_core::{RngCore, TryRngCore},
 };
 use sha2::Sha256;
-use srp::{client::Client, groups::G2048, server::Server};
+use srp::{Client, G2048, Server};
 
 fn auth_test_rfc5054(true_pwd: &[u8], auth_pwd: &[u8]) {
     let mut rng = SysRng.unwrap_err();


### PR DESCRIPTION
Flattens out modules, re-exporting all types from the toplevel.