### PR TITLE
srp: `Client*` and `Server*` type aliases

### DIFF
--- a/srp/src/groups.rs
+++ b/srp/src/groups.rs
@@ -1,7 +1,7 @@
-//! Groups from [RFC 5054](https://tools.ietf.org/html/rfc5054)
+//! Groups from [RFC5054](https://tools.ietf.org/html/rfc5054)
 //!
 //! It is strongly recommended to use them instead of custom generated
-//! groups. Additionally, it is not recommended to use `G1024` and `G_1536`,
+//! groups. Additionally, it is not recommended to use `G1024` and `G1536`,
 //! they are provided only for compatibility with the legacy software.
 
 use core::{

--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -34,7 +34,8 @@
 //! (`N = 2q + 1`, where `q` is prime).
 //!
 //! Additionally, `g` MUST be a generator modulo `N`. It's STRONGLY recommended to use SRP
-//! parameters provided by this crate as [`G1024`], [`G1536`], [`G2048`], [`G3072`] and [`G4096`].
+//! parameters provided by this crate under the [`groups`] module, and available as various
+//! type aliases e.g. [`ClientG2048`] and [`ServerG2048`].
 //!
 //! |       Client           |   Data transfer   |      Server                     |
 //! |------------------------|-------------------|---------------------------------|
@@ -69,17 +70,22 @@
 #[macro_use]
 extern crate alloc;
 
-mod client;
-mod errors;
-mod groups;
-mod server;
+pub mod groups;
 #[doc(hidden)]
 pub mod utils;
 
-pub use client::{Client, ClientVerifier};
+mod client;
+mod errors;
+mod server;
+
+pub use client::{
+    Client, ClientG1024, ClientG1536, ClientG2048, ClientG3072, ClientG4096, ClientVerifier,
+};
 pub use errors::AuthError;
-pub use groups::*;
-pub use server::{Server, ServerVerifier};
+pub use groups::Group;
+pub use server::{
+    Server, ServerG1024, ServerG1536, ServerG2048, ServerG3072, ServerG4096, ServerVerifier,
+};
 
 #[allow(deprecated)]
 pub use {client::LegacyClientVerifier, server::LegacyServerVerifier};

--- a/srp/tests/bad_public.rs
+++ b/srp/tests/bad_public.rs
@@ -1,6 +1,6 @@
 use crypto_bigint::BoxedUint;
 use sha1::Sha1;
-use srp::{Client, G1024, Server};
+use srp::{Client, Server, groups::G1024};
 
 #[test]
 #[should_panic]

--- a/srp/tests/rfc5054.rs
+++ b/srp/tests/rfc5054.rs
@@ -2,7 +2,7 @@ use crypto_bigint::BoxedUint;
 use hex_literal::hex;
 use sha1::Sha1;
 use srp::utils::{compute_k, compute_u};
-use srp::{Client, G1024, Group, Server};
+use srp::{Client, Group, Server, groups::G1024};
 
 #[test]
 #[allow(clippy::many_single_char_names)]

--- a/srp/tests/srp.rs
+++ b/srp/tests/srp.rs
@@ -3,7 +3,7 @@ use getrandom::{
     rand_core::{RngCore, TryRngCore},
 };
 use sha2::Sha256;
-use srp::{Client, G2048, Server};
+use srp::{Client, Server, groups::G2048};
 
 fn auth_test_rfc5054(true_pwd: &[u8], auth_pwd: &[u8]) {
     let mut rng = SysRng.unwrap_err();


### PR DESCRIPTION
Adds type aliases (still parameterized by a generic `D`) which are already configured with the appropriate SRP groups, e.g `ClientG2048`, `ServerG2048`.