### PR TITLE
srp: deprecate `G1024` and `G1536`

### DIFF
--- a/srp/src/client.rs
+++ b/srp/src/client.rs
@@ -6,8 +6,12 @@ use digest::{Digest, Output};
 use subtle::ConstantTimeEq;
 
 /// SRP client configured with a standard 1024-bit group.
+#[deprecated(since = "0.7.0", note = "too small to be secure; use a larger group")]
+#[allow(deprecated)]
 pub type ClientG1024<D> = Client<G1024, D>;
 /// SRP client configured with a standard 1536-bit group.
+#[deprecated(since = "0.7.0", note = "too small to be secure; use a larger group")]
+#[allow(deprecated)]
 pub type ClientG1536<D> = Client<G1536, D>;
 /// SRP client configured with a standard 2048-bit group.
 pub type ClientG2048<D> = Client<G2048, D>;

--- a/srp/src/groups.rs
+++ b/srp/src/groups.rs
@@ -1,8 +1,11 @@
-//! Groups from [RFC5054](https://tools.ietf.org/html/rfc5054)
+//! Groups from [RFC5054].
 //!
-//! It is strongly recommended to use them instead of custom generated
-//! groups. Additionally, it is not recommended to use `G1024` and `G1536`,
+//! It is strongly recommended to use them instead of custom generated groups.
+//!
+//! Additionally, it is NOT recommended to use [`G1024`] and [`G1536`],
 //! they are provided only for compatibility with the legacy software.
+//!
+//! [RFC5054]: https://tools.ietf.org/html/rfc5054
 
 use core::{
     any,
@@ -35,12 +38,39 @@ macro_rules! define_group {
         #[doc = $doc]
         #[derive(Clone, Copy)]
         pub struct $name;
+        group_trait_impls!($name, $g, $n);
+    };
+}
 
+macro_rules! define_deprecated_group {
+    ($name:ident, $g:expr, $n:expr, $doc:expr) => {
+        /// DEPRECATED:
+        #[doc = $doc]
+        ///
+        /// <div class="warning">
+        /// <b>Warning: small group size!</b>
+        ///
+        /// It is recommended to use a group which is 2048-bits or larger.
+        /// </div>
+        #[derive(Clone, Copy)]
+        #[deprecated(
+            since = "0.7.0",
+            note = "this group is too small to be secure. Prefer to use G2048+"
+        )]
+        pub struct $name;
+        group_trait_impls!($name, $g, $n);
+    };
+}
+
+macro_rules! group_trait_impls {
+    ($name:ident, $g:expr, $n:expr) => {
+        #[allow(deprecated)]
         impl Group for $name {
             const G: u64 = $g;
-            const N: &'static [u8] = include_bytes!("groups/1024.bin");
+            const N: &'static [u8] = include_bytes!($n);
         }
 
+        #[allow(deprecated)]
         impl Debug for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 let name = any::type_name::<$name>();
@@ -54,6 +84,7 @@ macro_rules! define_group {
             }
         }
 
+        #[allow(deprecated)]
         impl<Rhs: Group> PartialEq<Rhs> for $name {
             fn eq(&self, _other: &Rhs) -> bool {
                 Self::G == Rhs::G && Self::N == Rhs::N
@@ -62,13 +93,14 @@ macro_rules! define_group {
     };
 }
 
-define_group!(G1024, 2, "groups/1024.bin", "1024-bit group.");
-define_group!(G1536, 2, "groups/1536.bin", "1536-bit group.");
+define_deprecated_group!(G1024, 2, "groups/1024.bin", "1024-bit group.");
+define_deprecated_group!(G1536, 2, "groups/1536.bin", "1536-bit group.");
 define_group!(G2048, 2, "groups/2048.bin", "2048-bit group.");
 define_group!(G3072, 5, "groups/3072.bin", "3072-bit group.");
 define_group!(G4096, 5, "groups/4096.bin", "4096-bit group.");
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::{G1024, Group};
     use crate::utils::compute_k;

--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -78,14 +78,13 @@ mod client;
 mod errors;
 mod server;
 
-pub use client::{
-    Client, ClientG1024, ClientG1536, ClientG2048, ClientG3072, ClientG4096, ClientVerifier,
-};
+pub use client::{Client, ClientG2048, ClientG3072, ClientG4096, ClientVerifier};
 pub use errors::AuthError;
 pub use groups::Group;
-pub use server::{
-    Server, ServerG1024, ServerG1536, ServerG2048, ServerG3072, ServerG4096, ServerVerifier,
-};
+pub use server::{Server, ServerG2048, ServerG3072, ServerG4096, ServerVerifier};
 
 #[allow(deprecated)]
-pub use {client::LegacyClientVerifier, server::LegacyServerVerifier};
+pub use {
+    client::{ClientG1024, ClientG1536, LegacyClientVerifier},
+    server::{LegacyServerVerifier, ServerG1024, ServerG1536},
+};

--- a/srp/src/server.rs
+++ b/srp/src/server.rs
@@ -6,8 +6,12 @@ use digest::{Digest, Output};
 use subtle::ConstantTimeEq;
 
 /// SRP server configured with a standard [`G1024`] group.
+#[deprecated(since = "0.7.0", note = "too small to be secure; use a larger group")]
+#[allow(deprecated)]
 pub type ServerG1024<D> = Server<G1024, D>;
 /// SRP server configured with a standard [`G1536`] group.
+#[deprecated(since = "0.7.0", note = "too small to be secure; use a larger group")]
+#[allow(deprecated)]
 pub type ServerG1536<D> = Server<G1536, D>;
 /// SRP server configured with a standard [`G2048`] group.
 pub type ServerG2048<D> = Server<G2048, D>;

--- a/srp/tests/bad_public.rs
+++ b/srp/tests/bad_public.rs
@@ -1,11 +1,11 @@
 use crypto_bigint::BoxedUint;
 use sha1::Sha1;
-use srp::{Client, Server, groups::G1024};
+use srp::{ClientG2048, ServerG2048};
 
 #[test]
 #[should_panic]
 fn bad_a_pub() {
-    let server = Server::<G1024, Sha1>::new();
+    let server = ServerG2048::<Sha1>::new();
     server
         .process_reply(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();
@@ -14,7 +14,7 @@ fn bad_a_pub() {
 #[test]
 #[should_panic]
 fn bad_b_pub() {
-    let client = Client::<G1024, Sha1>::new();
+    let client = ClientG2048::<Sha1>::new();
     client
         .process_reply(b"", b"", b"", b"", &BoxedUint::zero().to_be_bytes())
         .unwrap();

--- a/srp/tests/rfc5054.rs
+++ b/srp/tests/rfc5054.rs
@@ -2,11 +2,13 @@ use crypto_bigint::BoxedUint;
 use hex_literal::hex;
 use sha1::Sha1;
 use srp::utils::{compute_k, compute_u};
-use srp::{Client, Group, Server, groups::G1024};
+use srp::{Client, Group, Server};
 
 #[test]
-#[allow(clippy::many_single_char_names)]
+#[allow(clippy::many_single_char_names, deprecated)]
 fn rfc5054() {
+    use srp::groups::G1024;
+
     let i = b"alice";
     let p = b"password123";
     let s = hex!("BEB25379 D1A8581E B5A72767 3A2441EE");


### PR DESCRIPTION
These groups are smaller than 2048-bits, which makes them too small to be secure. This preserves them (several of our tests reference them) but adds a deprecation warning.