### PR TITLE
srp: add `getrandom` and `rand_core` features

### DIFF
--- a/.github/workflows/srp.yml
+++ b/.github/workflows/srp.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --no-default-features
 
   test:
     runs-on: ubuntu-latest
@@ -49,4 +49,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --release
+      - run: cargo test --no-default-features
+      - run: cargo test
+      - run: cargo test --all-features
+      - run: cargo test --all-features --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfc44c334576a43ddece6194e3bf6f177b402728fde319648e36aaf617a473c7"
 dependencies = [
  "ctutils",
+ "getrandom",
  "num-traits",
  "rand_core",
  "serdect",
@@ -137,7 +138,9 @@ version = "0.2.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41b8986f836d4aeb30ccf4c9d3bd562fd716074cfd7fc4a2948359fbd21ed809"
 dependencies = [
+ "getrandom",
  "hybrid-array",
+ "rand_core",
 ]
 
 [[package]]
@@ -552,6 +555,7 @@ name = "srp"
 version = "0.7.0-pre.2"
 dependencies = [
  "crypto-bigint",
+ "crypto-common",
  "digest",
  "getrandom",
  "hex-literal",

--- a/srp/Cargo.toml
+++ b/srp/Cargo.toml
@@ -17,7 +17,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-crypto-bigint = { version = "0.7.0-rc.17", features = ["alloc"] }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.17", features = ["alloc"] }
+common = { package = "crypto-common", version = "0.2.0-rc.9" }
 digest = "0.11.0-rc.5"
 subtle = { version = "2.4", default-features = false }
 
@@ -26,3 +27,11 @@ getrandom = { version = "0.4.0-rc.0", features = ["sys_rng"] }
 hex-literal = "1"
 sha1 = "0.11.0-rc.3"
 sha2 = "0.11.0-rc.3"
+
+[features]
+default = ["getrandom"]
+getrandom = ["rand_core", "bigint/getrandom", "common/getrandom"]
+rand_core = ["common/rand_core"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/srp/src/groups.rs
+++ b/srp/src/groups.rs
@@ -7,13 +7,13 @@
 //!
 //! [RFC5054]: https://tools.ietf.org/html/rfc5054
 
+use bigint::{
+    BoxedUint, Odd, Resize,
+    modular::{BoxedMontyForm, BoxedMontyParams},
+};
 use core::{
     any,
     fmt::{self, Debug},
-};
-use crypto_bigint::{
-    BoxedUint, Odd, Resize,
-    modular::{BoxedMontyForm, BoxedMontyParams},
 };
 
 /// Group used for SRP computations.

--- a/srp/src/lib.rs
+++ b/srp/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -78,7 +79,9 @@ mod client;
 mod errors;
 mod server;
 
+pub use bigint;
 pub use client::{Client, ClientG2048, ClientG3072, ClientG4096, ClientVerifier};
+pub use common;
 pub use errors::AuthError;
 pub use groups::Group;
 pub use server::{Server, ServerG2048, ServerG3072, ServerG4096, ServerVerifier};
@@ -88,3 +91,16 @@ pub use {
     client::{ClientG1024, ClientG1536, LegacyClientVerifier},
     server::{LegacyServerVerifier, ServerG1024, ServerG1536},
 };
+
+#[cfg(feature = "rand_core")]
+pub use common::Generate;
+#[cfg(feature = "rand_core")]
+pub use common::rand_core;
+
+/// 384-bit ephemeral secret (usable as `a` or `b`).
+///
+/// Should be large enough for use with any of the groups defined in this crate.
+pub type EphemeralSecret = [u8; 48];
+
+/// 256-bit salt value.
+pub type Salt = [u8; 16];

--- a/srp/src/utils.rs
+++ b/srp/src/utils.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use crypto_bigint::{
+use bigint::{
     BoxedUint, Resize,
     modular::{BoxedMontyForm, BoxedMontyParams},
 };

--- a/srp/tests/bad_public.rs
+++ b/srp/tests/bad_public.rs
@@ -1,4 +1,4 @@
-use crypto_bigint::BoxedUint;
+use bigint::BoxedUint;
 use sha1::Sha1;
 use srp::{ClientG2048, ServerG2048};
 

--- a/srp/tests/rfc5054.rs
+++ b/srp/tests/rfc5054.rs
@@ -1,4 +1,4 @@
-use crypto_bigint::BoxedUint;
+use bigint::BoxedUint;
 use hex_literal::hex;
 use sha1::Sha1;
 use srp::utils::{compute_k, compute_u};


### PR DESCRIPTION
Also adds an `EphemeralSecret` type alias.

Updates the docs to use the `Generate` trait to generate an `EphemeralSecret`, instead of the example using all zeros with a comment that you should probably fill that zero array using an RNG somehow.