### PR TITLE
Reapply "srp: add HomeKit-compatible padding for u and M1/M2"

### DIFF
--- a/srp/src/client.rs
+++ b/srp/src/client.rs
@@ -228,6 +228,7 @@ impl<G: Group, D: Digest> Client<G, D> {
 
         let m1 = compute_m1_rfc5054::<D>(
             &self.g,
+            false,
             username,
             salt,
             &a_pub_bytes,

--- a/srp/src/client.rs
+++ b/srp/src/client.rs
@@ -215,7 +215,7 @@ impl<G: Group, D: Digest> Client<G, D> {
         // Safeguard against malicious B
         self.validate_b_pub(&b_pub)?;
 
-        let u = compute_u::<D>(&a_pub_bytes, b_pub_bytes);
+        let u = compute_u_padded::<D>(&self.g, &a_pub_bytes, b_pub_bytes);
         let k = compute_k::<D>(&self.g);
         let identity_hash = Self::compute_identity_hash(self.identity_username(username), password);
         let x = Self::compute_x(identity_hash.as_slice(), salt);


### PR DESCRIPTION
This reverts commit 22d096a01ff796591593f3267c1c10398cfcd378 (#283)

This was originally added in #272 then reverted due to bugs which weren't caught in CI at the time, but are now captured by proptests